### PR TITLE
Don't error on the default help command, or version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ vet
 .vagrant/
 local/
 tls-gen/
+
+perfTest/perfTest

--- a/perfTest/cmd/silent.go
+++ b/perfTest/cmd/silent.go
@@ -10,16 +10,24 @@ import (
 	"github.com/spf13/cobra"
 	"math/rand"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 )
+
+var wg sync.WaitGroup
 
 func newSilent() *cobra.Command {
 	var silentCmd = &cobra.Command{
 		Use:   "silent",
 		Short: "NewProducer a silent simulation",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return startSimulation()
+			wg.Add(1)
+			err := startSimulation()
+			if err == nil {
+				wg.Wait()
+			}
+			return err
 		},
 	}
 	return silentCmd

--- a/perfTest/cmd/version.go
+++ b/perfTest/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -22,8 +21,7 @@ var versionCmd = &cobra.Command{
 }
 
 func printVersion() {
-	fmt.Printf("%s version: %s\ngo version: %s\ncommit: %s\n",
-		rabbitmqBrokerUrl,
+	fmt.Printf("version: %s\ngo version: %s\ncommit: %s\n",
 		version,
 		goVersion,
 		commit,

--- a/perfTest/perftest.go
+++ b/perfTest/perftest.go
@@ -2,14 +2,8 @@ package main
 
 import (
 	"github.com/rabbitmq/rabbitmq-stream-go-client/perfTest/cmd"
-	"sync"
 )
 
-var wg sync.WaitGroup
-
 func main() {
-
-	wg.Add(1)
-	go cmd.Execute()
-	wg.Wait()
+	cmd.Execute()
 }


### PR DESCRIPTION
This addresses https://github.com/rabbitmq/rabbitmq-stream-go-client/issues/71.

While working on this, I realised a few things:
- The `PerfTest [command]` actually originates in cobra's default usage template, specifically here https://github.com/spf13/cobra/blob/4fd30b69ee2b62cf3bbecf0a423f8a1ee47f5f24/command.go#L493
- Rather than making a change in cobra, I think that the `silent` command should be the default one. The name always grated me, and now I know why: it doesn't say anything about what it does. WDYT @Gsantomaggio ?

By the way, I think that this CLI could learn a lot from https://clig.dev