### PR TITLE
Make stream creation idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ err = env.DeclareStream(streamName,
 ```
 
 The function `DeclareStream` doesn't return errors if a stream is already defined with the same parameters.
+Note that it returns the precondition failed when it doesn't have the same parameters
 Use `StreamExists` to check if a stream exists.
 
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ err = env.DeclareStream(streamName,
 		SetMaxLengthBytes(stream.ByteCapacity{}.GB(2)))
 ```
 
-Note: The function `DeclareStream` returns `stream.StreamAlreadyExists` if a stream is already defined.
+The function `DeclareStream` doesn't return errors if a stream is already defined with the same parameters.
+Use `StreamExists` to check if a stream exists.
 
 
 ### Publish messages

--- a/pkg/stream/client_test.go
+++ b/pkg/stream/client_test.go
@@ -115,8 +115,19 @@ var _ = Describe("Streaming testEnvironment", func() {
 	It("Create two times Stream", func() {
 		Expect(testEnvironment.DeclareStream(testStreamName, nil)).NotTo(HaveOccurred())
 		err := testEnvironment.DeclareStream(testStreamName, nil)
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(StreamAlreadyExists))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(testEnvironment.DeleteStream(testStreamName)).NotTo(HaveOccurred())
+	})
+
+	It("Stream Exists", func() {
+		exists, err := testEnvironment.StreamExists(testStreamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(Equal(false))
+
+		Expect(testEnvironment.DeclareStream(testStreamName, nil)).NotTo(HaveOccurred())
+		exists, err = testEnvironment.StreamExists(testStreamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(Equal(true))
 		Expect(testEnvironment.DeleteStream(testStreamName)).NotTo(HaveOccurred())
 	})
 

--- a/pkg/stream/enviroment.go
+++ b/pkg/stream/enviroment.go
@@ -104,7 +104,11 @@ func (env *Environment) DeclareStream(streamName string, options *StreamOptions)
 	if err != nil {
 		return err
 	}
-	return client.DeclareStream(streamName, options)
+	errCreateStream := client.DeclareStream(streamName, options)
+	if errCreateStream == StreamAlreadyExists {
+		return nil
+	}
+	return errCreateStream
 }
 
 func (env *Environment) DeleteStream(streamName string) error {

--- a/pkg/stream/enviroment.go
+++ b/pkg/stream/enviroment.go
@@ -104,11 +104,11 @@ func (env *Environment) DeclareStream(streamName string, options *StreamOptions)
 	if err != nil {
 		return err
 	}
-	errCreateStream := client.DeclareStream(streamName, options)
-	if errCreateStream == StreamAlreadyExists {
-		return nil
+	if err := client.DeclareStream(streamName, options); err != nil && err != StreamAlreadyExists {
+		return err
 	}
-	return errCreateStream
+	return nil
+
 }
 
 func (env *Environment) DeleteStream(streamName string) error {


### PR DESCRIPTION
closes https://github.com/rabbitmq/rabbitmq-stream-go-client/issues/99

Create the stream idempotent way only if the parameters are the same.
`Precondition Failed` error is raised in In case the stream has different parameters 

use `env.StreamExists(streamName)` to check if the stream exists 