### PR TITLE
Refactor stream package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,15 @@ $(GOMOCK):
 .PHONY: gomock
 gomock: $(GOMOCK)
 
+NUM_PROCS ?= 2
+TEST_TIMEOUT ?= 2m
 test: vet fmt check
-	go test -race -tags debug -v -cpu 2 ./pkg/stream -coverprofile coverage.txt -covermode atomic -ginkgo.v -timeout=2m
+	go run github.com/onsi/ginkgo/v2/ginkgo -r --procs=$(NUM_PROCS) --compilers=$(NUM_PROCS) \
+		--randomize-all --randomize-suites \
+		--cover --coverprofile=coverage.txt --covermode=atomic \
+		--race --trace \
+		--tags debug \
+		--timeout=$(TEST_TIMEOUT)
 
 build-all: vet fmt check build-darwin build-windows build-linux
 

--- a/go.mod
+++ b/go.mod
@@ -15,11 +15,15 @@ require (
 
 require (
 	github.com/frankban/quicktest v1.14.2 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/tools v0.1.10 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnX
 github.com/frankban/quicktest v1.14.2/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -28,6 +29,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -123,10 +125,10 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -272,6 +272,7 @@ var _ = Describe("Streaming Consumers", func() {
 
 		chConfirm := producer.NotifyPublishConfirmation()
 		go func(ch ChannelPublishConfirm, p *Producer) {
+			defer GinkgoRecover()
 			for ids := range ch {
 				for _, msg := range ids {
 					Expect(msg.GetError()).NotTo(HaveOccurred())
@@ -420,6 +421,7 @@ var _ = Describe("Streaming Consumers", func() {
 
 		chConfirm := producer.NotifyPublishConfirmation()
 		go func(ch ChannelPublishConfirm, p *Producer) {
+			defer GinkgoRecover()
 			for ids := range ch {
 				for _, msg := range ids {
 					Expect(msg.GetMessage().GetMessageProperties().To).To(Equal("ToTest"))
@@ -473,6 +475,7 @@ var _ = Describe("Streaming Consumers", func() {
 
 		chConfirm := producer.NotifyPublishConfirmation()
 		go func(ch ChannelPublishConfirm, p *Producer) {
+			defer GinkgoRecover()
 			for ids := range ch {
 				for _, msg := range ids {
 					Expect(msg.GetMessage().GetApplicationProperties()["key1"]).To(Equal("value1"))

--- a/pkg/stream/enviroment_test.go
+++ b/pkg/stream/enviroment_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var _ = Describe("Environment test", func() {
+	const testVhost = "rabbitmq-streams-go-test"
 
 	It("Multi Producers", func() {
 		env, err := NewEnvironment(nil)

--- a/pkg/stream/enviroment_test.go
+++ b/pkg/stream/enviroment_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Environment test", func() {
 		for i := 0; i < 5; i++ {
 			wg.Add(1)
 			go func(wg *sync.WaitGroup) {
+				defer GinkgoRecover()
 				producer, err := env.NewProducer(streamName, nil)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(20 * time.Millisecond)
@@ -105,6 +106,7 @@ var _ = Describe("Environment test", func() {
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				_, errProd := env.NewProducer(streamNameWillBeDelete, nil)
 				Expect(errProd).NotTo(HaveOccurred())
 				_, errProd = env.NewProducer(streamNameWillBeDeleteAfter, nil)

--- a/pkg/stream/stream_suite_test.go
+++ b/pkg/stream/stream_suite_test.go
@@ -1,14 +1,57 @@
 package stream_test
 
 import (
-	"testing"
-
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"net/http"
+	"testing"
 )
+
+const testVhost = "rabbitmq-streams-go-test"
 
 func TestStream(t *testing.T) {
 	defer GinkgoRecover()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Go-streaming-client")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	err := createVhost(testVhost)
+	Expect(err).NotTo(HaveOccurred())
+	return nil
+}, func(_ []byte) {})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	Expect(deleteVhost(testVhost)).NotTo(HaveOccurred())
+})
+
+func createVhost(vhost string) error {
+	return httpCall("PUT", vhostUrl(vhost))
+}
+
+func deleteVhost(vhost string) error {
+	return httpCall("DELETE", vhostUrl(vhost))
+}
+
+func vhostUrl(vhost string) string {
+	return fmt.Sprintf("http://guest:guest@localhost:15672/api/vhosts/%s", vhost)
+}
+
+func httpCall(method, url string) error {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http error (%d): %s", resp.StatusCode, resp.Status)
+	}
+	return nil
 }

--- a/pkg/stream/types.go
+++ b/pkg/stream/types.go
@@ -1,0 +1,15 @@
+package stream
+
+//go:generate mockgen . BaseEnvironment
+type BaseEnvironment interface {
+	DeclareStream(streamName string, options *StreamOptions) error
+	DeleteStream(streamName string) error
+	NewProducer(streamName string, producerOptions *ProducerOptions) (*Producer, error)
+	StreamExists(streamName string) (bool, error)
+	QueryOffset(consumerName string, streamName string) (int64, error)
+	QuerySequence(publisherReference string, streamName string) (int64, error)
+	StreamMetaData(streamName string) (*StreamMetadata, error)
+	NewConsumer(streamName string,
+		messagesHandler MessagesHandler,
+		options *ConsumerOptions) (*Consumer, error)
+}

--- a/pkg/stream/utils_test.go
+++ b/pkg/stream/utils_test.go
@@ -15,6 +15,7 @@ var _ = Describe("Utils", func() {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func(res *Response) {
+			defer GinkgoRecover()
 			err := waitCodeWithDefaultTimeOut(res)
 			Expect(err.Err).ToNot(HaveOccurred())
 			wg.Done()
@@ -33,6 +34,7 @@ var _ = Describe("Utils", func() {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func(res *Response) {
+			defer GinkgoRecover()
 			err := waitCodeWithDefaultTimeOut(res)
 			Expect(err.Err).To(HaveOccurred())
 			wg.Done()


### PR DESCRIPTION

## Summary

- Refactor socket module
- Refactor stream module tests
- Update Makefile
- Update go routines in tests

The `socket` module was using `sync/atomic` and `sync/mutex`. Using both is not necessary, and atomic
package may give headaches to users in architectures other than amd64. This PR changes the module to use
only mutexes.

The Makefile is changed to permit starting RabbitMQ using different container technologies, like containerd
with `nerdctl` cli. Not everyone is happy to Docker's recent license change :-) It also uses ginkgo as test
runner. It allows to use the same flags as `go test` and it provides a more condensed output, perhaps easier
to read.

The before/after suite functions have been moved to the suite test file, where they belong :-)

