### PR TITLE
Fix timeout error log message

### DIFF
--- a/.github/workflows/test_and_publish_image.yml
+++ b/.github/workflows/test_and_publish_image.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
-      - run: make test
+      - run: make test GO_VERSION=${{ matrix.go }}
       - name: Upload code coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash)
   test-win32:
@@ -49,7 +49,7 @@ jobs:
         run: ./.ci/install.ps1
       - name: Install GNU make
         run: choco install make
-      - run: make test
+      - run: make test GO_VERSION=${{ matrix.go }}
   publish:
     runs-on: ubuntu-latest
     needs: [test, test-win32]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,15 @@ else
 GOBIN = $(shell go env GOBIN)
 endif
 
+ifdef GO_VERSION
+	ifeq ($(GO_VERSION),1.18)
+		STATICCHECK_VERSION=2022.1.3
+	endif
+	ifeq ($(GO_VERSION),1.17)
+		STATICCHECK_VERSION=2021.1.2
+	endif
+endif
+
 VERSION ?= latest
 LDFLAGS = "-X main.Version=$(VERSION)"
 
@@ -17,8 +26,9 @@ fmt:
 	go fmt ./...
 
 STATICCHECK ?= $(GOBIN)/staticcheck
+STATICCHECK_VERSION ?= latest
 $(STATICCHECK):
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
 check: $(STATICCHECK)
 	$(STATICCHECK) ./pkg/stream
 
@@ -58,7 +68,7 @@ perf-test-run: perf-test-build
 perf-test-help: perf-test-build
 	go run perfTest/perftest.go help
 
-perf-test-build: vet fmt check
+perf-test-build:
 	go build -ldflags=$(LDFLAGS) -o bin/stream-perf-test perfTest/perftest.go
 
 BUILDKIT ?= docker

--- a/pkg/stream/utils.go
+++ b/pkg/stream/utils.go
@@ -41,11 +41,11 @@ func waitCodeWithTimeOut(response *Response, timeout time.Duration) responseErro
 		}
 		return newResponseError(nil, false)
 	case <-time.After(timeout):
-		logs.LogError("timeout %d ms - waiting Code, operation: %s", defaultSocketCallTimeout, response.commandDescription)
+		logs.LogError("timeout %d ns - waiting Code, operation: %s", defaultSocketCallTimeout.Milliseconds(), response.commandDescription)
 
 		return newResponseError(
 			fmt.Errorf("timeout %d ms - waiting Code, operation: %s ",
-				defaultSocketCallTimeout, response.commandDescription), true)
+				defaultSocketCallTimeout.Milliseconds(), response.commandDescription), true)
 	}
 }
 


### PR DESCRIPTION
## Summary

Duration prints its value in nanoseconds. Earlier, we were printing: "timeout 10000000000 ms <...>", which is not correct. The default timeout is 10 seconds or 10,000 ms.

## Testing

Start `nc` as follows:

```bash
nc -l localhost 5552
```

Run stream perf-test in a different terminal. Observe the error message after 10 seconds.