### PR TITLE
Add initial-credits flag to perfTest

### DIFF
--- a/perfTest/cmd/commands.go
+++ b/perfTest/cmd/commands.go
@@ -45,6 +45,7 @@ var (
 	debugLogs           bool
 	crcCheck            bool
 	runDuration         int
+	initialCredits      int
 )
 
 func init() {
@@ -74,6 +75,7 @@ func setupCli(baseCmd *cobra.Command) {
 	baseCmd.PersistentFlags().IntVarP(&maxAge, "max-age", "", 0, "Stream Age in hours, e.g. 1,2.. 24 , etc.")
 	baseCmd.PersistentFlags().StringVarP(&maxSegmentSizeBytes, "stream-max-segment-size-bytes", "", "500MB", "Stream segment size bytes, e.g. 10MB, 1GB, etc.")
 	baseCmd.PersistentFlags().StringVarP(&consumerOffset, "consumer-offset", "", "first", "Staring consuming, ex: first,last,next or random")
+	baseCmd.PersistentFlags().IntVarP(&initialCredits, "initial-credits", "", 10, "Consumer initial credits")
 	baseCmd.AddCommand(versionCmd)
 	baseCmd.AddCommand(newSilent())
 }

--- a/perfTest/cmd/silent.go
+++ b/perfTest/cmd/silent.go
@@ -390,7 +390,10 @@ func startConsumer(consumerName string, streamName string) error {
 		streamName,
 		handleMessages,
 		stream.NewConsumerOptions().
-			SetConsumerName(consumerName).SetOffset(offsetSpec).SetCRCCheck(crcCheck))
+			SetConsumerName(consumerName).
+			SetOffset(offsetSpec).
+			SetCRCCheck(crcCheck).
+			SetInitialCredits(int16(initialCredits)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For small message sizes, the default initial credit value of 10 is too low, resulting in decreased consumer performance.

This exposes the initial credit configuration, so users can decide on what values works best for them.

The default is kept the same.