### PR TITLE
QuerySequence v2

### DIFF
--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -239,6 +239,20 @@ func (e *Environment) QueryOffset(ctx context.Context, consumer, stream string) 
 			// pick at random
 			l = e.pickLocator((i + rn) % n)
 		}
+		result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
+		if result[1] != nil {
+			lastError = result[1].(error)
+			if isNonRetryableError(lastError) {
+				return 0, lastError
+			}
+		}
+		result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
+		if result[1] != nil {
+			lastError = result[1].(error)
+			if isNonRetryableError(lastError) {
+				return uint64(0), lastError
+			}
+		}
 
 		if err := l.maybeInitializeLocator(); err != nil {
 			lastError = err

--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -239,20 +239,6 @@ func (e *Environment) QueryOffset(ctx context.Context, consumer, stream string) 
 			// pick at random
 			l = e.pickLocator((i + rn) % n)
 		}
-		result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
-		if result[1] != nil {
-			lastError = result[1].(error)
-			if isNonRetryableError(lastError) {
-				return 0, lastError
-			}
-		}
-		result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
-		if result[1] != nil {
-			lastError = result[1].(error)
-			if isNonRetryableError(lastError) {
-				return uint64(0), lastError
-			}
-		}
 
 		if err := l.maybeInitializeLocator(); err != nil {
 			lastError = err
@@ -315,22 +301,35 @@ func (e *Environment) QueryPartitions(ctx context.Context, superstream string) (
 	return nil, lastError
 }
 
+// QuerySequence retrieves the last publishingID for a given producer
+// (reference) and stream name.
 func (e *Environment) QuerySequence(ctx context.Context, reference, stream string) (uint64, error) {
+	logger := raw.LoggerFromCtxOrDiscard(ctx)
+	rn := rand.Intn(100)
+	n := len(e.locators)
+
 	var lastError error
-	l := e.pickLocator(0)
-	if err := l.maybeInitializeLocator(); err != nil {
-		lastError = err
-	}
-
-	result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
-	if result[1] != nil {
-		lastError = result[1].(error)
-		if isNonRetryableError(lastError) {
-			return 0, lastError
+	for i := 0; i < n; i++ {
+		l := e.pickLocator((i + rn) % n)
+		if err := l.maybeInitializeLocator(); err != nil {
+			lastError = err
+			logger.Error("error initializing locator", slog.Any("error", err))
+			continue
 		}
+
+		result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
+		if result[1] != nil {
+			lastError = result[1].(error)
+			if isNonRetryableError(lastError) {
+				return uint64(0), lastError
+			}
+			logger.Error("locator operation failed", slog.Any("error", lastError))
+			continue
+		}
+
+		pubId := result[0].(uint64)
+		return pubId, nil
 	}
 
-	pubId := result[0].(uint64)
-
-	return pubId, nil
+	return uint64(0), lastError
 }

--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -311,7 +311,6 @@ func (e *Environment) QuerySequence(ctx context.Context, reference, stream strin
 
 	if !validateStringParameter(reference) {
 		lastError = fmt.Errorf("producer reference invalid: %s", reference)
-		logger.Error("invalid producer reference", slog.Any("error", lastError))
 		return uint64(0), lastError
 	}
 

--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -300,3 +300,23 @@ func (e *Environment) QueryPartitions(ctx context.Context, superstream string) (
 	}
 	return nil, lastError
 }
+
+func (e *Environment) QuerySequence(ctx context.Context, reference, stream string) (uint64, error) {
+	var lastError error
+	l := e.pickLocator(0)
+	if err := l.maybeInitializeLocator(); err != nil {
+		lastError = err
+	}
+
+	result := l.locatorOperation((*locator).operationQuerySequence, ctx, reference, stream)
+	if result[1] != nil {
+		lastError = result[1].(error)
+		if isNonRetryableError(lastError) {
+			return 0, lastError
+		}
+	}
+
+	pubId := result[0].(uint64)
+
+	return pubId, nil
+}

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -632,8 +632,7 @@ var _ = Describe("Environment", func() {
 
 		It("queries last publishingid for a given producer and stream", func() {
 			// setup
-			var publishingId uint64
-			publishingId = 42
+			publishingId := uint64(42)
 			mockRawClient.EXPECT().
 				QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
 				Return(publishingId, nil)
@@ -648,8 +647,7 @@ var _ = Describe("Environment", func() {
 		When("there is an error", func() {
 			It("bubbles up the error", func() {
 				// setup
-				var publishingId uint64
-				publishingId = 0
+				publishingId := uint64(0)
 
 				mockRawClient.EXPECT().
 					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -431,6 +431,7 @@ var _ = Describe("Environment", func() {
 
 			Eventually(logBuffer).Within(time.Millisecond * 500).Should(gbytes.Say(`"locator operation failed" error="err maybe later"`))
 		})
+
 	})
 
 	Context("query offset", func() {
@@ -620,6 +621,28 @@ var _ = Describe("Environment", func() {
 			Expect(err).To(HaveOccurred())
 
 			Eventually(logBuffer).Within(time.Millisecond * 500).Should(gbytes.Say(`"locator operation failed" error="err maybe later"`))
+		})
+	})
+
+	Context("query sequence", func() {
+		BeforeEach(func() {
+			mockRawClient.EXPECT().
+				IsOpen().
+				Return(true) // from maybeInitializeLocator
+		})
+
+		It("queries last publishingid for a given producer and stream", func() {
+			// setup
+			var publishingId uint64
+			publishingId = 42
+			mockRawClient.EXPECT().
+				QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+				Return(publishingId, nil)
+
+			// act
+			pubId, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pubId).To(BeNumerically("==", 42))
 		})
 	})
 })

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -624,122 +624,122 @@ var _ = Describe("Environment", func() {
 	})
 
 	Context("query sequence", func() {
-    Context("input validation succeeds", func() {
+		Context("input validation succeeds", func() {
 
-      BeforeEach(func() {
-        mockRawClient.EXPECT().
-          IsOpen().
-          Return(true) // from maybeInitializeLocator
-      })
+			BeforeEach(func() {
+				mockRawClient.EXPECT().
+					IsOpen().
+					Return(true) // from maybeInitializeLocator
+			})
 
-      It("queries last publishingid for a given producer and stream", func() {
-        // setup
-        publishingId := uint64(42)
-        mockRawClient.EXPECT().
-          QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-          Return(publishingId, nil)
+			It("queries last publishingid for a given producer and stream", func() {
+				// setup
+				publishingId := uint64(42)
+				mockRawClient.EXPECT().
+					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+					Return(publishingId, nil)
 
-        // act
-        pubId, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
-        Expect(err).ToNot(HaveOccurred())
-        Expect(pubId).To(BeNumerically("==", 42))
+				// act
+				pubId, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pubId).To(BeNumerically("==", 42))
 
-      })
+			})
 
-      When("there is an error", func() {
-        It("bubbles up the error", func() {
-          // setup
-          publishingId := uint64(0)
+			When("there is an error", func() {
+				It("bubbles up the error", func() {
+					// setup
+					publishingId := uint64(0)
 
-          mockRawClient.EXPECT().
-            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-            Return(publishingId, errors.New("err not today")).
-            Times(3)
+					mockRawClient.EXPECT().
+						QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+						Return(publishingId, errors.New("err not today")).
+						Times(3)
 
-          _, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
-          Expect(err).To(MatchError("err not today"))
-        })
+					_, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
+					Expect(err).To(MatchError("err not today"))
+				})
 
-      })
+			})
 
-      When("there are multiple locators", func() {
-        var (
-          locator2rawClient *stream.MockRawClient
-        )
+			When("there are multiple locators", func() {
+				var (
+					locator2rawClient *stream.MockRawClient
+				)
 
-        BeforeEach(func() {
-          locator2rawClient = stream.NewMockRawClient(mockCtrl)
-          environment.AppendLocatorRawClient(locator2rawClient)
-          environment.SetBackoffPolicy(backOffPolicyFn)
-          environment.SetLocatorSelectSequential(true)
+				BeforeEach(func() {
+					locator2rawClient = stream.NewMockRawClient(mockCtrl)
+					environment.AppendLocatorRawClient(locator2rawClient)
+					environment.SetBackoffPolicy(backOffPolicyFn)
+					environment.SetLocatorSelectSequential(true)
 
-          // have to set server version again because there's a new locator
-          // environment.SetServerVersion("3.11.1")
-        })
+					// have to set server version again because there's a new locator
+					// environment.SetServerVersion("3.11.1")
+				})
 
-        It("uses different locators when one fails", func() {
-          // setup
-          locator2rawClient.EXPECT().
-            IsOpen().
-            Return(true)
-          locator2rawClient.EXPECT().
-            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-            Return(uint64(42), nil)
+				It("uses different locators when one fails", func() {
+					// setup
+					locator2rawClient.EXPECT().
+						IsOpen().
+						Return(true)
+					locator2rawClient.EXPECT().
+						QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+						Return(uint64(42), nil)
 
-          mockRawClient.EXPECT().
-            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-            Return(uint64(0), errors.New("something went wrong")).
-            Times(3)
+					mockRawClient.EXPECT().
+						QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+						Return(uint64(0), errors.New("something went wrong")).
+						Times(3)
 
-          // act
-          pubId, err := environment.QuerySequence(rootCtx, "retried-stream-stats", "stream-id")
-          Expect(err).ToNot(HaveOccurred())
-          Expect(pubId).To(BeNumerically("==", 42))
-        })
+					// act
+					pubId, err := environment.QuerySequence(rootCtx, "retried-stream-stats", "stream-id")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pubId).To(BeNumerically("==", 42))
+				})
 
-        It("gives up on non-retryable errors", func() {
-          // setup
-          mockRawClient.EXPECT().
-            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.Eq("non-retryable"), gomock.AssignableToTypeOf("string")).
-            Return(uint64(0), raw.ErrInternalError)
+				It("gives up on non-retryable errors", func() {
+					// setup
+					mockRawClient.EXPECT().
+						QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.Eq("non-retryable"), gomock.AssignableToTypeOf("string")).
+						Return(uint64(0), raw.ErrInternalError)
 
-          // act
-          _, err := environment.QuerySequence(rootCtx, "non-retryable", "stream")
-          Expect(err).To(HaveOccurred())
-        })
-      })
+					// act
+					_, err := environment.QuerySequence(rootCtx, "non-retryable", "stream")
+					Expect(err).To(HaveOccurred())
+				})
+			})
 
-      It("logs intermediate error messages", func() {
-        // setup
-        logBuffer := gbytes.NewBuffer()
-        logger := slog.New(slog.NewTextHandler(logBuffer))
-        ctx := raw.NewContextWithLogger(context.Background(), *logger)
+			It("logs intermediate error messages", func() {
+				// setup
+				logBuffer := gbytes.NewBuffer()
+				logger := slog.New(slog.NewTextHandler(logBuffer))
+				ctx := raw.NewContextWithLogger(context.Background(), *logger)
 
-        mockRawClient.EXPECT().
-          QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-          Return(uint64(0), errors.New("err maybe later")).
-          Times(3)
+				mockRawClient.EXPECT().
+					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+					Return(uint64(0), errors.New("err maybe later")).
+					Times(3)
 
-        // act
-        _, err := environment.QuerySequence(ctx, "log-things", "stream")
-        Expect(err).To(HaveOccurred())
+				// act
+				_, err := environment.QuerySequence(ctx, "log-things", "stream")
+				Expect(err).To(HaveOccurred())
 
-        Eventually(logBuffer).Within(time.Millisecond * 500).Should(gbytes.Say(`"locator operation failed" error="err maybe later"`))
-      })
-    })
+				Eventually(logBuffer).Within(time.Millisecond * 500).Should(gbytes.Say(`"locator operation failed" error="err maybe later"`))
+			})
+		})
 
-    Context("input validation fails", func() {
-      It("validates that reference is not a nil string", func() {
+		Context("input validation fails", func() {
+			It("validates that reference is not a nil string", func() {
 
-        _, err := environment.QuerySequence(rootCtx, "", "stream-id")
-        Expect(err).To(MatchError("producer reference invalid: "))
-      })
+				_, err := environment.QuerySequence(rootCtx, "", "stream-id")
+				Expect(err).To(MatchError("producer reference invalid: "))
+			})
 
-      It("validates that reference is not a whitespace char", func() {
-        // setup
-        _, err := environment.QuerySequence(rootCtx, " ", "stream-id")
-        Expect(err).To(MatchError("producer reference invalid:  "))
-      })
-    })
-  })
+			It("validates that reference is not a whitespace char", func() {
+				// setup
+				_, err := environment.QuerySequence(rootCtx, " ", "stream-id")
+				Expect(err).To(MatchError("producer reference invalid:  "))
+			})
+		})
+	})
 })

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -672,9 +672,6 @@ var _ = Describe("Environment", func() {
 					environment.AppendLocatorRawClient(locator2rawClient)
 					environment.SetBackoffPolicy(backOffPolicyFn)
 					environment.SetLocatorSelectSequential(true)
-
-					// have to set server version again because there's a new locator
-					// environment.SetServerVersion("3.11.1")
 				})
 
 				It("uses different locators when one fails", func() {

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -624,108 +624,122 @@ var _ = Describe("Environment", func() {
 	})
 
 	Context("query sequence", func() {
-		BeforeEach(func() {
-			mockRawClient.EXPECT().
-				IsOpen().
-				Return(true) // from maybeInitializeLocator
-		})
+    Context("input validation succeeds", func() {
 
-		It("queries last publishingid for a given producer and stream", func() {
-			// setup
-			publishingId := uint64(42)
-			mockRawClient.EXPECT().
-				QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-				Return(publishingId, nil)
+      BeforeEach(func() {
+        mockRawClient.EXPECT().
+          IsOpen().
+          Return(true) // from maybeInitializeLocator
+      })
 
-			// act
-			pubId, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pubId).To(BeNumerically("==", 42))
+      It("queries last publishingid for a given producer and stream", func() {
+        // setup
+        publishingId := uint64(42)
+        mockRawClient.EXPECT().
+          QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+          Return(publishingId, nil)
 
-		})
+        // act
+        pubId, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
+        Expect(err).ToNot(HaveOccurred())
+        Expect(pubId).To(BeNumerically("==", 42))
 
-		When("there is an error", func() {
-			It("bubbles up the error", func() {
-				// setup
-				publishingId := uint64(0)
+      })
 
-				mockRawClient.EXPECT().
-					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-					Return(publishingId, errors.New("err not today")).
-					Times(3)
+      When("there is an error", func() {
+        It("bubbles up the error", func() {
+          // setup
+          publishingId := uint64(0)
 
-				_, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
-				Expect(err).To(MatchError("err not today"))
-			})
-		})
+          mockRawClient.EXPECT().
+            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+            Return(publishingId, errors.New("err not today")).
+            Times(3)
 
-		When("there are multiple locators", FlakeAttempts(3), Label("flaky"), func() {
-			var (
-				locator2rawClient *stream.MockRawClient
-			)
+          _, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
+          Expect(err).To(MatchError("err not today"))
+        })
 
-			BeforeEach(func() {
-				locator2rawClient = stream.NewMockRawClient(mockCtrl)
-				environment.AppendLocatorRawClient(locator2rawClient)
-				environment.SetBackoffPolicy(backOffPolicyFn)
+      })
 
-				// have to set server version again because there's a new locator
-				environment.SetServerVersion("3.11.1")
-			})
+      When("there are multiple locators", func() {
+        var (
+          locator2rawClient *stream.MockRawClient
+        )
 
-			It("uses different locators when one fails", func() {
-				// setup
-				var publishingId uint64
-				var nilPublishingId uint64
-				publishingId = 42
-				nilPublishingId = 0
+        BeforeEach(func() {
+          locator2rawClient = stream.NewMockRawClient(mockCtrl)
+          environment.AppendLocatorRawClient(locator2rawClient)
+          environment.SetBackoffPolicy(backOffPolicyFn)
+          environment.SetLocatorSelectSequential(true)
 
-				locator2rawClient.EXPECT().
-					IsOpen().
-					Return(true)
-				locator2rawClient.EXPECT().
-					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-					Return(publishingId, nil)
+          // have to set server version again because there's a new locator
+          // environment.SetServerVersion("3.11.1")
+        })
 
-				mockRawClient.EXPECT().
-					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-					Return(nilPublishingId, errors.New("something went wrong")).
-					Times(3)
+        It("uses different locators when one fails", func() {
+          // setup
+          locator2rawClient.EXPECT().
+            IsOpen().
+            Return(true)
+          locator2rawClient.EXPECT().
+            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+            Return(uint64(42), nil)
 
-				// act
-				pubId, err := environment.QuerySequence(rootCtx, "retried-stream-stats", "stream-id")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(pubId).To(BeNumerically("==", 42))
-			})
+          mockRawClient.EXPECT().
+            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+            Return(uint64(0), errors.New("something went wrong")).
+            Times(3)
 
-			It("gives up on non-retryable errors", func() {
-				// setup
-				mockRawClient.EXPECT().
-					QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.Eq("non-retryable"), gomock.AssignableToTypeOf("string")).
-					Return(uint64(0), raw.ErrStreamDoesNotExist)
+          // act
+          pubId, err := environment.QuerySequence(rootCtx, "retried-stream-stats", "stream-id")
+          Expect(err).ToNot(HaveOccurred())
+          Expect(pubId).To(BeNumerically("==", 42))
+        })
 
-				// act
-				_, err := environment.QuerySequence(rootCtx, "non-retryable", "stream")
-				Expect(err).To(HaveOccurred())
-			})
-		})
+        It("gives up on non-retryable errors", func() {
+          // setup
+          mockRawClient.EXPECT().
+            QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.Eq("non-retryable"), gomock.AssignableToTypeOf("string")).
+            Return(uint64(0), raw.ErrInternalError)
 
-		It("logs intermediate error messages", func() {
-			// setup
-			logBuffer := gbytes.NewBuffer()
-			logger := slog.New(slog.NewTextHandler(logBuffer))
-			ctx := raw.NewContextWithLogger(context.Background(), *logger)
+          // act
+          _, err := environment.QuerySequence(rootCtx, "non-retryable", "stream")
+          Expect(err).To(HaveOccurred())
+        })
+      })
 
-			mockRawClient.EXPECT().
-				QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
-				Return(uint64(0), errors.New("err maybe later")).
-				Times(3)
+      It("logs intermediate error messages", func() {
+        // setup
+        logBuffer := gbytes.NewBuffer()
+        logger := slog.New(slog.NewTextHandler(logBuffer))
+        ctx := raw.NewContextWithLogger(context.Background(), *logger)
 
-			// act
-			_, err := environment.QuerySequence(ctx, "log-things", "stream")
-			Expect(err).To(HaveOccurred())
+        mockRawClient.EXPECT().
+          QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+          Return(uint64(0), errors.New("err maybe later")).
+          Times(3)
 
-			Eventually(logBuffer).Within(time.Millisecond * 500).Should(gbytes.Say(`"locator operation failed" error="err maybe later"`))
-		})
-	})
+        // act
+        _, err := environment.QuerySequence(ctx, "log-things", "stream")
+        Expect(err).To(HaveOccurred())
+
+        Eventually(logBuffer).Within(time.Millisecond * 500).Should(gbytes.Say(`"locator operation failed" error="err maybe later"`))
+      })
+    })
+
+    Context("input validation fails", func() {
+      It("validates that reference is not a nil string", func() {
+
+        _, err := environment.QuerySequence(rootCtx, "", "stream-id")
+        Expect(err).To(MatchError("producer reference invalid: "))
+      })
+
+      It("validates that reference is not a whitespace char", func() {
+        // setup
+        _, err := environment.QuerySequence(rootCtx, " ", "stream-id")
+        Expect(err).To(MatchError("producer reference invalid:  "))
+      })
+    })
+  })
 })

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -643,6 +643,22 @@ var _ = Describe("Environment", func() {
 			pubId, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pubId).To(BeNumerically("==", 42))
+
+		})
+
+		When("there is an error", func() {
+			It("bubbles up the error", func() {
+				// setup
+      var publishingId uint64
+      publishingId = 0
+				mockRawClient.EXPECT().
+				QueryPublisherSequence(gomock.AssignableToTypeOf(ctxType), gomock.AssignableToTypeOf("string"), gomock.AssignableToTypeOf("string")).
+					Return(publishingId, errors.New("err not today")).
+					Times(3)
+
+        _, err := environment.QuerySequence(rootCtx, "producer-id", "stream-id")
+				Expect(err).To(MatchError("err not today"))
+			})
 		})
 	})
 })

--- a/pkg/stream/locator.go
+++ b/pkg/stream/locator.go
@@ -204,10 +204,17 @@ func (l *locator) operationQueryOffset(args ...any) []any {
 	offset, err := l.client.QueryOffset(ctx, reference, stream)
 	return []any{offset, err}
 }
-
 func (l *locator) operationPartitions(args ...any) []any {
 	ctx := args[0].(context.Context)
 	superstream := args[1].(string)
 	partitions, err := l.client.Partitions(ctx, superstream)
 	return []any{partitions, err}
+}
+
+func (l *locator) operationQuerySequence(args ...any) []any {
+	ctx := args[0].(context.Context)
+	reference := args[1].(string)
+	stream := args[2].(string)
+	pubId, err := l.client.QueryPublisherSequence(ctx, reference, stream)
+	return []any{pubId, err}
 }

--- a/pkg/stream/util.go
+++ b/pkg/stream/util.go
@@ -60,3 +60,11 @@ func maybeApplyDefaultTimeout(ctx context.Context) (context.Context, context.Can
 	}
 	return ctx, nil
 }
+
+func validateStringParameter(p string) bool {
+	if len(p) == 0 || p == " " {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Closes #228
This PR adds QuerySequence to the public API for v2
 - QuerySequence retreives the publsihingID for a given producer and stream name.
 - The retry tests inherit the same flaky behaviour as QueryStreamStats
 - QuerySequence returns a uint64 and an error. 
 - Similar to stream stats loggin events occur if the selecte locator fails to initialize, or of the locator operation fails. 

Question for reviewers, should the public functions return a custom type to encapsulate data from the raw layer? (see QueryStreamStats where we have a stream.Stats type)