### PR TITLE
pkg/client/stream: fix deadlock for client methods

### DIFF
--- a/pkg/stream/client_test.go
+++ b/pkg/stream/client_test.go
@@ -1,6 +1,8 @@
 package stream
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"time"
 
@@ -178,5 +180,35 @@ var _ = Describe("Streaming testEnvironment", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(fmt.Sprintf("%s", err)).
 			To(ContainSubstring("stream Name can't be empty"))
+	})
+
+	It("Client.queryOffset won't hang if timeout happens", func() {
+		cli := newClient("connName", nil, nil, nil)
+		cli.socket.writer = bufio.NewWriter(bytes.NewBuffer([]byte{}))
+		cli.socketCallTimeout = time.Millisecond
+
+		res, err := cli.queryOffset("cons", "stream")
+		Expect(err.Error()).To(ContainSubstring("timeout 1 ms - waiting Code, operation: CommandQueryOffset"))
+		Expect(res).To(BeZero())
+	})
+
+	It("Client.queryPublisherSequence won't hang if timeout happens", func() {
+		cli := newClient("connName", nil, nil, nil)
+		cli.socket.writer = bufio.NewWriter(bytes.NewBuffer([]byte{}))
+		cli.socketCallTimeout = time.Millisecond
+
+		res, err := cli.queryPublisherSequence("ref", "stream")
+		Expect(err.Error()).To(ContainSubstring("timeout 1 ms - waiting Code, operation: Command not handled 5"))
+		Expect(res).To(BeZero())
+	})
+
+	It("Client.StreamStats won't hang if timeout happens", func() {
+		cli := newClient("connName", nil, nil, nil)
+		cli.socket.writer = bufio.NewWriter(bytes.NewBuffer([]byte{}))
+		cli.socketCallTimeout = time.Millisecond
+
+		res, err := cli.StreamStats("stream")
+		Expect(err.Error()).To(ContainSubstring("timeout 1 ms - waiting Code, operation: Command not handled 28"))
+		Expect(res).To(BeNil())
 	})
 })

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -132,7 +132,7 @@ func newResponse(commandDescription string) *Response {
 	res := &Response{}
 	res.commandDescription = commandDescription
 	res.code = make(chan Code, 1)
-	res.data = make(chan interface{})
+	res.data = make(chan interface{}, 1)
 	res.offsetMessages = make(chan offsetMessages, 100)
 	return res
 }

--- a/pkg/stream/socket.go
+++ b/pkg/stream/socket.go
@@ -67,7 +67,7 @@ func (c *Client) handleWrite(buffer []byte, response *Response) responseError {
 
 func (c *Client) handleWriteWithResponse(buffer []byte, response *Response, removeResponse bool) responseError {
 	result := c.socket.writeAndFlush(buffer)
-	resultCode := waitCodeWithDefaultTimeOut(response)
+	resultCode := waitCodeWithTimeOut(response, c.socketCallTimeout)
 	/// we need to remove the response before evaluate the
 	// buffer errSocket
 	if removeResponse {

--- a/pkg/stream/utils.go
+++ b/pkg/stream/utils.go
@@ -41,11 +41,11 @@ func waitCodeWithTimeOut(response *Response, timeout time.Duration) responseErro
 		}
 		return newResponseError(nil, false)
 	case <-time.After(timeout):
-		logs.LogError("timeout %d ns - waiting Code, operation: %s", defaultSocketCallTimeout.Milliseconds(), response.commandDescription)
+		logs.LogError("timeout %d ns - waiting Code, operation: %s", timeout.Milliseconds(), response.commandDescription)
 
 		return newResponseError(
 			fmt.Errorf("timeout %d ms - waiting Code, operation: %s ",
-				defaultSocketCallTimeout.Milliseconds(), response.commandDescription), true)
+				timeout.Milliseconds(), response.commandDescription), true)
 	}
 }
 


### PR DESCRIPTION
Client.queryOffset/queryPublisherSequence/StreamStats were fixed to prevent deadlock in case of request timeout (for example rabbit server is down). Now these methods returns error immidiately if it occured and doesn't try to read from data chanel, because in case of request timeout it hangs (no other gorouitine would write to this channel).

Also Client is extended with additional field socketCallTimeout, for testing purposes (decrease running time of new tests).

Closes #273