### PR TITLE
Expose GetEntriesCount chunk information

### DIFF
--- a/examples/getting_started.go
+++ b/examples/getting_started.go
@@ -78,7 +78,7 @@ func main() {
 
 	// the send method automatically aggregates the messages
 	// based on batch size
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 10000; i++ {
 		err := producer.Send(amqp.NewMessage([]byte("hello_world_" + strconv.Itoa(i))))
 		CheckErr(err)
 	}
@@ -94,7 +94,9 @@ func main() {
 	//}, nil)
 	// if you need to track the offset you need a consumer name like:
 	handleMessages := func(consumerContext stream.ConsumerContext, message *amqp.Message) {
-		fmt.Printf("consumer name: %s, text: %s \n ", consumerContext.Consumer.GetName(), message.Data)
+
+		fmt.Printf("consumer name: %s, data: %s, message offset %d, chunk entities count: %d   \n ",
+			consumerContext.Consumer.GetName(), message.Data, consumerContext.Consumer.GetOffset(), consumerContext.GetEntriesCount())
 	}
 
 	consumer, err := env.NewConsumer(

--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -811,10 +811,10 @@ func (c *Client) DeclareSubscriber(streamName string,
 					return
 				}
 
-			case offsetMessages := <-consumer.response.offsetMessages:
-				for _, offMessage := range offsetMessages {
+			case chunk := <-consumer.response.chunkForConsumer:
+				for _, offMessage := range chunk.offsetMessages {
 					consumer.setCurrentOffset(offMessage.offset)
-					consumer.MessagesHandler(ConsumerContext{Consumer: consumer}, offMessage.message)
+					consumer.MessagesHandler(ConsumerContext{Consumer: consumer, chunkInfo: &chunk}, offMessage.message)
 					if consumer.options.autocommit {
 						consumer.messageCountBeforeStorage += 1
 						if consumer.messageCountBeforeStorage >= consumer.options.autoCommitStrategy.messageCountBeforeStorage {

--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -101,7 +101,12 @@ func (consumer *Consumer) NotifyClose() ChannelClose {
 }
 
 type ConsumerContext struct {
-	Consumer *Consumer
+	Consumer  *Consumer
+	chunkInfo *chunkInfo
+}
+
+func (cc ConsumerContext) GetEntriesCount() uint16 {
+	return cc.chunkInfo.numEntries
 }
 
 type MessagesHandler func(consumerContext ConsumerContext, message *amqp.Message)

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -29,11 +29,15 @@ type offsetMessage struct {
 }
 
 type offsetMessages = []*offsetMessage
+type chunkInfo struct {
+	offsetMessages offsetMessages
+	numEntries     uint16
+}
 
 type Response struct {
 	code               chan Code
 	data               chan interface{}
-	offsetMessages     chan offsetMessages
+	chunkForConsumer   chan chunkInfo
 	commandDescription string
 	correlationid      int
 }
@@ -119,7 +123,7 @@ func (coordinator *Coordinator) RemoveResponseById(id interface{}) error {
 	err = coordinator.removeById(fmt.Sprintf("%d", id), coordinator.responses)
 	close(resp.code)
 	close(resp.data)
-	close(resp.offsetMessages)
+	close(resp.chunkForConsumer)
 	return err
 }
 
@@ -133,7 +137,7 @@ func newResponse(commandDescription string) *Response {
 	res.commandDescription = commandDescription
 	res.code = make(chan Code, 1)
 	res.data = make(chan interface{})
-	res.offsetMessages = make(chan offsetMessages, 100)
+	res.chunkForConsumer = make(chan chunkInfo, 100)
 	return res
 }
 


### PR DESCRIPTION
Expose some chunk information. For the moment, I'd start with `GetEntriesCount` which gives the number of entities for chunk. 