### PR TITLE
Avoid to create filtering producer with subentry batch

### DIFF
--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -528,6 +528,9 @@ func (c *Client) DeclarePublisher(streamName string, options *ProducerOptions) (
 		return nil, FilterNotSupported
 	}
 
+	if options.isSubEntriesBatching() && options.IsFilterEnabled() {
+		return nil, fmt.Errorf("sub-entry batching can't be enabled with filter")
+	}
 	if options.QueueSize < minQueuePublisherSize || options.QueueSize > maxQueuePublisherSize {
 		return nil, fmt.Errorf("QueueSize values must be between %d and %d",
 			minQueuePublisherSize, maxQueuePublisherSize)

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -180,9 +180,6 @@ var _ = Describe("Streaming Consumers", func() {
 		producer, err := env.NewProducer(streamName, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = producer.BatchSend(CreateArrayMessagesForTesting(5)) // batch send
-		Expect(err).NotTo(HaveOccurred())
-		Expect(producer.Close()).NotTo(HaveOccurred())
 		var messagesCount int32 = 0
 		consumer, err := env.NewConsumer(streamName,
 			func(consumerContext ConsumerContext, message *amqp.Message) {
@@ -190,12 +187,13 @@ var _ = Describe("Streaming Consumers", func() {
 			}, NewConsumerOptions().
 				SetOffset(OffsetSpecification{}.First()))
 		Expect(err).NotTo(HaveOccurred())
-
+		err = producer.BatchSend(CreateArrayMessagesForTesting(5)) // batch send
+		Expect(err).NotTo(HaveOccurred())
+		Expect(producer.Close()).NotTo(HaveOccurred())
 		Eventually(func() int32 {
 			return atomic.LoadInt32(&messagesCount)
 		}, 5*time.Second).Should(Equal(int32(5)),
-			"chunkInfo should be 5") // 30 messages since the offset is 10 but all the messages are received
-
+			"chunkInfo should be 5")
 		Expect(consumer.Close()).NotTo(HaveOccurred())
 	})
 

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -499,7 +499,9 @@ func (producer *Producer) internalBatchSendProdId(messagesSequence []messageSequ
 		return fmt.Errorf("producer id: %d closed", producer.id)
 	}
 
-	if producer.options.IsFilterEnabled() {
+	if producer.options.IsFilterEnabled() &&
+		// this check is just for safety. The producer can't be created with Filter and SubEntry > 1
+		!producer.options.isSubEntriesBatching() {
 		return producer.sendWithFilter(messagesSequence, producerID)
 	}
 


### PR DESCRIPTION
Add a control to avoid to create a filtering producer with subentry bach enabled