### PR TITLE
remove the LastOffset()

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,6 @@ stats, err := environment.StreamStats(testStreamName)
 
 firstOffset, err := stats.FirstOffset() // first offset of the stream
 
-// LastOffset - The last offset in the stream.
-// return last offset in the stream
-// error if there is no first offset yet
-lastOffset, err := stats.LastOffset() // last offset of the stream
-
 // CommittedChunkId - The ID (offset) of the committed chunk (block of messages) in the stream.
 //
 //	It is the offset of the first message in the last chunk confirmed by a quorum of the stream

--- a/pkg/stream/stream_stats.go
+++ b/pkg/stream/stream_stats.go
@@ -22,9 +22,8 @@ func (s *StreamStats) FirstOffset() (int64, error) {
 	return s.stats["first_chunk_id"], nil
 }
 
-// LastOffset - The last offset in the stream.
-// return last offset in the stream
-// error if there is no first offset yet
+// Deprecated: The method name may be misleading.
+// It does not indicate the last offset of the stream. It indicates the last uncommited chunk id. This information is not necessary. The user should use CommittedChunkId().
 func (s *StreamStats) LastOffset() (int64, error) {
 	if s.stats["last_chunk_id"] == -1 {
 		return -1, fmt.Errorf("LastOffset not found for %s", s.streamName)


### PR DESCRIPTION
The method name may be misleading. It does not indicate the last offset of the stream. It indicates the last uncommited chunk id. This information is not necessary. The user should use CommittedChunkId().