### PR TITLE
change log level when consumer channel is closed

### DIFF
--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -415,7 +415,7 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 	if consumer.getStatus() == open {
 		consumer.response.chunkForConsumer <- chunk
 	} else {
-		logs.LogWarn("Consumer %s is closed", consumer.GetStreamName())
+		logs.LogDebug("Consumer %s is closed", consumer.GetStreamName())
 	}
 
 }


### PR DESCRIPTION
This change helps to avoid continuously generating logs in a production environment when we only need a single message and then close the channel.