### PR TITLE
Reduce `minBatchPublishingDelay` to 1ms

### DIFF
--- a/pkg/stream/constants.go
+++ b/pkg/stream/constants.go
@@ -104,7 +104,7 @@ const (
 	minSubEntrySize = 1
 	maxSubEntrySize = 65535
 
-	minBatchPublishingDelay = 50
+	minBatchPublishingDelay = 1
 	maxBatchPublishingDelay = 500
 
 	defaultBatchSize            = 100


### PR DESCRIPTION
Reduce `minBatchPublishingDelay` to 1ms instead of 50ms.
Discussion: https://github.com/rabbitmq/rabbitmq-stream-go-client/issues/332