### PR TITLE
Fix the reconnection logic for parallel writes with HA Producer.

### DIFF
--- a/pkg/ha/ha_publisher_test.go
+++ b/pkg/ha/ha_publisher_test.go
@@ -124,6 +124,7 @@ var _ = Describe("Reliable Producer", func() {
 	})
 
 	It("unblock all Reliable Producer sends while restarting with concurrent writes", func() {
+		const expectedMessages = 2
 		signal := make(chan struct{})
 		var confirmed int32
 		clientProvidedName := uuid.New().String()
@@ -135,7 +136,7 @@ var _ = Describe("Reliable Producer", func() {
 				for _, confirm := range messageConfirm {
 					Expect(confirm.IsConfirmed()).To(BeTrue())
 				}
-				if atomic.AddInt32(&confirmed, int32(len(messageConfirm))) == 2 {
+				if atomic.AddInt32(&confirmed, int32(len(messageConfirm))) == expectedMessages {
 					signal <- struct{}{}
 				}
 			})


### PR DESCRIPTION
If there are parallel calls to `Send` or `BatchSend` in concurrent routines during reconnection, only one of these sends will unlock and send the message, while the others will remain in a locked state. This is because currently there isn't a broadcast notification with reconnectionSignal. 
To fix this issue the `reconnectionSigna`l channel has been changed to a `sync.Cond`.