### PR TITLE
fix offset of single active consumer reset to 0

### DIFF
--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -891,7 +891,9 @@ func (c *Client) DeclareSubscriber(streamName string,
 	// copy the option offset to the consumer offset
 	// the option.offset won't change ( in case we need to retrive the original configuration)
 	// consumer.current offset will be moved when reading
-	consumer.setCurrentOffset(options.Offset.offset)
+	if !options.IsSingleActiveConsumerEnabled() {
+		consumer.setCurrentOffset(options.Offset.offset)
+	}
 
 	/// define the consumerOptions
 	consumerProperties := make(map[string]string)

--- a/pkg/stream/consumer_sac_test.go
+++ b/pkg/stream/consumer_sac_test.go
@@ -228,7 +228,6 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 			func(consumerContext ConsumerContext, message *amqp.Message) {
 				atomic.AddInt32(&messagesReceived, 1)
 			}, NewConsumerOptions().
-				SetOffset(OffsetSpecification{}.Offset(offset)).
 				SetConsumerName("my_consumer").
 				SetSingleActiveConsumer(NewSingleActiveConsumer(consumerUpdate)).
 				SetAutoCommit(nil))

--- a/pkg/stream/consumer_sac_test.go
+++ b/pkg/stream/consumer_sac_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		var messagesReceived int32 = 0
-		consumer, err := testEnvironment.NewConsumer(streamName,
+		consumerA, err := testEnvironment.NewConsumer(streamName,
 			func(consumerContext ConsumerContext, message *amqp.Message) {
 				atomic.AddInt32(&messagesReceived, 1)
 			}, NewConsumerOptions().
@@ -207,8 +207,8 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 		}, 5*time.Second).Should(Equal(int32(10)),
 			"consumer should receive only 10 messages")
 
-		Expect(consumer.Close()).NotTo(HaveOccurred())
-		Expect(consumer.GetLastStoredOffset()).To(Equal(int64(9)))
+		Expect(consumerA.Close()).NotTo(HaveOccurred())
+		Expect(consumerA.GetLastStoredOffset()).To(Equal(int64(9)))
 
 		offset, err := testEnvironment.QueryOffset("my_consumer", streamName)
 		Expect(err).NotTo(HaveOccurred())
@@ -224,7 +224,7 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 		}
 
 		messagesReceived = 0
-		consumer, err = testEnvironment.NewConsumer(streamName,
+		consumerB, err := testEnvironment.NewConsumer(streamName,
 			func(consumerContext ConsumerContext, message *amqp.Message) {
 				atomic.AddInt32(&messagesReceived, 1)
 			}, NewConsumerOptions().
@@ -233,16 +233,16 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 				SetAutoCommit(nil))
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(consumer.Close()).NotTo(HaveOccurred())
+		Expect(consumerB.Close()).NotTo(HaveOccurred())
 		time.Sleep(100 * time.Millisecond)
 		Eventually(func() int32 {
 			return atomic.LoadInt32(&messagesReceived)
 		}, 5*time.Second).Should(Equal(int32(0)),
 			"consumer should have received no messages")
 
-		offset, err = testEnvironment.QueryOffset("my_consumer", streamName)
+		offsetAfter, err := testEnvironment.QueryOffset("my_consumer", streamName)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(offset).To(Equal(int64(9)))
+		Expect(offsetAfter).To(Equal(int64(9)))
 
 		Expect(producer.Close()).NotTo(HaveOccurred())
 	})

--- a/pkg/stream/consumer_sac_test.go
+++ b/pkg/stream/consumer_sac_test.go
@@ -187,4 +187,64 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 		Expect(c2.Close()).NotTo(HaveOccurred())
 	})
 
+	It("offset should not be overwritten by autocommit on consumer close when no messages have been consumed", func() {
+		producer, err := testEnvironment.NewProducer(streamName, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		var messagesReceived int32 = 0
+		consumer, err := testEnvironment.NewConsumer(streamName,
+			func(consumerContext ConsumerContext, message *amqp.Message) {
+				atomic.AddInt32(&messagesReceived, 1)
+			}, NewConsumerOptions().
+				SetOffset(OffsetSpecification{}.First()).
+				SetConsumerName("my_consumer").
+				SetAutoCommit(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(producer.BatchSend(CreateArrayMessagesForTesting(10))).NotTo(HaveOccurred())
+		Eventually(func() int32 {
+			return atomic.LoadInt32(&messagesReceived)
+		}, 5*time.Second).Should(Equal(int32(10)),
+			"consumer should receive only 10 messages")
+
+		Expect(consumer.Close()).NotTo(HaveOccurred())
+		Expect(consumer.GetLastStoredOffset()).To(Equal(int64(9)))
+
+		offset, err := testEnvironment.QueryOffset("my_consumer", streamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(offset).To(Equal(int64(9)))
+
+		consumerUpdate := func(streamName string, isActive bool) OffsetSpecification {
+			offset, err := testEnvironment.QueryOffset("my_consumer", streamName)
+			if err != nil {
+				return OffsetSpecification{}.First()
+			}
+
+			return OffsetSpecification{}.Offset(offset + 1)
+		}
+
+		messagesReceived = 0
+		consumer, err = testEnvironment.NewConsumer(streamName,
+			func(consumerContext ConsumerContext, message *amqp.Message) {
+				atomic.AddInt32(&messagesReceived, 1)
+			}, NewConsumerOptions().
+				SetOffset(OffsetSpecification{}.Offset(offset)).
+				SetConsumerName("my_consumer").
+				SetSingleActiveConsumer(NewSingleActiveConsumer(consumerUpdate)).
+				SetAutoCommit(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(consumer.Close()).NotTo(HaveOccurred())
+		Eventually(func() int32 {
+			return atomic.LoadInt32(&messagesReceived)
+		}, 5*time.Second).Should(Equal(int32(0)),
+			"consumer should have received no messages")
+
+		offset, err = testEnvironment.QueryOffset("my_consumer", streamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(offset).To(Equal(int64(9)))
+
+		Expect(producer.Close()).NotTo(HaveOccurred())
+	})
+
 })

--- a/pkg/stream/consumer_sac_test.go
+++ b/pkg/stream/consumer_sac_test.go
@@ -234,6 +234,7 @@ var _ = Describe("Streaming Single Active Consumer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(consumer.Close()).NotTo(HaveOccurred())
+		time.Sleep(100 * time.Millisecond)
 		Eventually(func() int32 {
 			return atomic.LoadInt32(&messagesReceived)
 		}, 5*time.Second).Should(Equal(int32(0)),

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -282,6 +282,56 @@ var _ = Describe("Streaming Consumers", func() {
 
 	})
 
+	It("offset should not be overwritten by autocommit on consumer close when no messages have been consumed", func() {
+		producer, err := env.NewProducer(streamName, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		var messagesReceived int32 = 0
+		consumer, err := env.NewConsumer(streamName,
+			func(consumerContext ConsumerContext, message *amqp.Message) {
+				atomic.AddInt32(&messagesReceived, 1)
+			}, NewConsumerOptions().
+				SetOffset(OffsetSpecification{}.First()).
+				SetConsumerName("my_consumer").
+				SetAutoCommit(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(producer.BatchSend(CreateArrayMessagesForTesting(10))).NotTo(HaveOccurred())
+		Eventually(func() int32 {
+			return atomic.LoadInt32(&messagesReceived)
+		}, 5*time.Second).Should(Equal(int32(10)),
+			"consumer should receive only 10 messages")
+
+		Expect(consumer.Close()).NotTo(HaveOccurred())
+		Expect(consumer.GetLastStoredOffset()).To(Equal(int64(9)))
+
+		offset, err := env.QueryOffset("my_consumer", streamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(offset).To(Equal(int64(9)))
+
+		messagesReceived = 0
+		consumer, err = env.NewConsumer(streamName,
+			func(consumerContext ConsumerContext, message *amqp.Message) {
+				atomic.AddInt32(&messagesReceived, 1)
+			}, NewConsumerOptions().
+				SetOffset(OffsetSpecification{}.Offset(offset)).
+				SetConsumerName("my_consumer").
+				SetAutoCommit(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(consumer.Close()).NotTo(HaveOccurred())
+		Eventually(func() int32 {
+			return atomic.LoadInt32(&messagesReceived)
+		}, 5*time.Second).Should(Equal(int32(0)),
+			"consumer should have received no messages")
+
+		offset, err = env.QueryOffset("my_consumer", streamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(offset).To(Equal(int64(9)))
+
+		Expect(producer.Close()).NotTo(HaveOccurred())
+	})
+
 	It("Deduplication", func() {
 		producerName := "producer-ded"
 		producer, err := env.NewProducer(streamName, NewProducerOptions().SetProducerName(producerName))

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -202,7 +202,6 @@ func (coordinator *Coordinator) NewConsumer(messagesHandler MessagesHandler,
 		status:             open,
 		mutex:              &sync.Mutex{},
 		MessagesHandler:    messagesHandler,
-		currentOffset:      -1, // currentOffset has to equal lastStoredOffset as the currentOffset 0 may otherwise be flushed to the server when the consumer is closed and auto commit is enabled
 		lastStoredOffset:   -1, // because 0 is a valid value for the offset
 		isPromotedAsActive: true,
 	}

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -198,11 +198,11 @@ func (coordinator *Coordinator) NewConsumer(messagesHandler MessagesHandler,
 	defer coordinator.mutex.Unlock()
 	var lastId, _ = coordinator.getNextConsumerItem()
 	var item = &Consumer{ID: lastId, options: parameters,
-		response:        newResponse(lookUpCommand(commandSubscribe)),
-		status:          open,
-		mutex:           &sync.Mutex{},
-		MessagesHandler: messagesHandler,
-		//currentOffset:      -1, // currentOffset has to equal lastStoredOffset as the currentOffset 0 may otherwise be flushed to the server when the consumer is closed and auto commit is enabled
+		response:           newResponse(lookUpCommand(commandSubscribe)),
+		status:             open,
+		mutex:              &sync.Mutex{},
+		MessagesHandler:    messagesHandler,
+		currentOffset:      -1, // currentOffset has to equal lastStoredOffset as the currentOffset 0 may otherwise be flushed to the server when the consumer is closed and auto commit is enabled
 		lastStoredOffset:   -1, // because 0 is a valid value for the offset
 		isPromotedAsActive: true,
 	}

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -198,11 +198,11 @@ func (coordinator *Coordinator) NewConsumer(messagesHandler MessagesHandler,
 	defer coordinator.mutex.Unlock()
 	var lastId, _ = coordinator.getNextConsumerItem()
 	var item = &Consumer{ID: lastId, options: parameters,
-		response:           newResponse(lookUpCommand(commandSubscribe)),
-		status:             open,
-		mutex:              &sync.Mutex{},
-		MessagesHandler:    messagesHandler,
-		currentOffset:      -1, // currentOffset has to equal lastStoredOffset as the currentOffset 0 may otherwise be flushed to the server when the consumer is closed and auto commit is enabled
+		response:        newResponse(lookUpCommand(commandSubscribe)),
+		status:          open,
+		mutex:           &sync.Mutex{},
+		MessagesHandler: messagesHandler,
+		//currentOffset:      -1, // currentOffset has to equal lastStoredOffset as the currentOffset 0 may otherwise be flushed to the server when the consumer is closed and auto commit is enabled
 		lastStoredOffset:   -1, // because 0 is a valid value for the offset
 		isPromotedAsActive: true,
 	}

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -202,6 +202,7 @@ func (coordinator *Coordinator) NewConsumer(messagesHandler MessagesHandler,
 		status:             open,
 		mutex:              &sync.Mutex{},
 		MessagesHandler:    messagesHandler,
+		currentOffset:      -1, // currentOffset has to equal lastStoredOffset as the currentOffset 0 may otherwise be flushed to the server when the consumer is closed and auto commit is enabled
 		lastStoredOffset:   -1, // because 0 is a valid value for the offset
 		isPromotedAsActive: true,
 	}

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -600,8 +600,6 @@ func (c *Client) handleConsumerUpdate(readProtocol *ReaderProtocol, r *bufio.Rea
 		return
 	}
 	consumer.setPromotedAsActive(isActive == 1)
-
-	// shouldn't this only be run if the consumer is active?
 	responseOff := consumer.options.SingleActiveConsumer.ConsumerUpdate(consumer.GetStreamName(),
 		isActive == 1)
 	consumer.options.SingleActiveConsumer.offsetSpecification = responseOff

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -606,9 +606,9 @@ func (c *Client) handleConsumerUpdate(readProtocol *ReaderProtocol, r *bufio.Rea
 		isActive == 1)
 	consumer.options.SingleActiveConsumer.offsetSpecification = responseOff
 
-	if isActive == 1 {
-		consumer.currentOffset = responseOff.offset
-	}
+	//if isActive == 1 {
+	//	consumer.currentOffset = responseOff.offset
+	//}
 
 	err = consumer.writeConsumeUpdateOffsetToSocket(readProtocol.CorrelationId, responseOff)
 	logErrorCommand(err, "handleConsumerUpdate writeConsumeUpdateOffsetToSocket")

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -607,7 +607,7 @@ func (c *Client) handleConsumerUpdate(readProtocol *ReaderProtocol, r *bufio.Rea
 	consumer.options.SingleActiveConsumer.offsetSpecification = responseOff
 
 	if isActive == 1 {
-		consumer.currentOffset = responseOff.offset
+		consumer.setCurrentOffset(responseOff.offset)
 	}
 
 	err = consumer.writeConsumeUpdateOffsetToSocket(readProtocol.CorrelationId, responseOff)

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -606,9 +606,9 @@ func (c *Client) handleConsumerUpdate(readProtocol *ReaderProtocol, r *bufio.Rea
 		isActive == 1)
 	consumer.options.SingleActiveConsumer.offsetSpecification = responseOff
 
-	//if isActive == 1 {
-	//	consumer.currentOffset = responseOff.offset
-	//}
+	if isActive == 1 {
+		consumer.currentOffset = responseOff.offset
+	}
 
 	err = consumer.writeConsumeUpdateOffsetToSocket(readProtocol.CorrelationId, responseOff)
 	logErrorCommand(err, "handleConsumerUpdate writeConsumeUpdateOffsetToSocket")

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -600,9 +600,16 @@ func (c *Client) handleConsumerUpdate(readProtocol *ReaderProtocol, r *bufio.Rea
 		return
 	}
 	consumer.setPromotedAsActive(isActive == 1)
+
+	// shouldn't this only be run if the consumer is active?
 	responseOff := consumer.options.SingleActiveConsumer.ConsumerUpdate(consumer.GetStreamName(),
 		isActive == 1)
 	consumer.options.SingleActiveConsumer.offsetSpecification = responseOff
+
+	if isActive == 1 {
+		consumer.currentOffset = responseOff.offset
+	}
+
 	err = consumer.writeConsumeUpdateOffsetToSocket(readProtocol.CorrelationId, responseOff)
 	logErrorCommand(err, "handleConsumerUpdate writeConsumeUpdateOffsetToSocket")
 }


### PR DESCRIPTION
When a single active consumer with an offset is closed while no messages have been consumed, the offset 0 is sent to the server when closing the consumer gracefully and auto commit is enabled.

Recently `lastStoredOffset` was changed to be initialized with -1 for #306 , however that change caused this bug because the offset is only sent when `lastStoredOffset < currentOffset`. Because currentOffset is set to 0 by default by offset next and the default 0 initalization, `lastStoredOffset < currentOffset` is true when closing the consumer resulting in the offset 0 being sent. Because no messages were consumed either the offset was not populated. 