### PR TITLE
Add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Enhancements 
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - Semver-Patch
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependency Updates
+      labels:
+        - dependencies


### PR DESCRIPTION
Added the `.github/release.yml` file to generate automatically release notes when creating a new release. More info [here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).

How it Works:

When creating a new release, by clicking the `Generate release notes` button will automatically fetch and categorize all the merged PRs between the latest tag and the new one, based on the labels in the PRs.

If multiple valid labels are present in a PR, it will choose the one with the highest priority, which is determined by the order they appear in the release.yml file.

If a PR contains the label `ignore-for-release` it will be skipped regardless of the other labels.

To benefit this feature, each PR should have at least one label from the list to be included in the auto-generation process. I can add a CI action to ensure that each PR has at least one and only one label, but I think it might be more annoying than useful. What do you think?

Also, can you give me your opinion about the categories and titles? Thanks