### PR TITLE
Check version when version is not

### DIFF
--- a/pkg/stream/available_features.go
+++ b/pkg/stream/available_features.go
@@ -45,7 +45,7 @@ func (a *availableFeatures) BrokerFilterEnabled() bool {
 func (a *availableFeatures) IsBrokerSingleActiveConsumerEnabled() bool {
 	lock.Lock()
 	defer lock.Unlock()
-	return a.brokerSingleActiveConsumerEnabled == a.is311OrMore
+	return a.brokerSingleActiveConsumerEnabled
 }
 
 func (a *availableFeatures) SetVersion(version string) error {

--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -218,7 +218,7 @@ func (c *Client) connect() error {
 		}
 
 		if serverProperties["version"] == "" || !c.availableFeatures.Is311OrMore() {
-			logs.LogInfo(
+			logs.LogDebug(
 				"Server version is less than 3.11.0, skipping command version exchange")
 		} else {
 			err := c.exchangeVersion(c.serverProperties["version"])

--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -212,13 +212,12 @@ func (c *Client) connect() error {
 			return err2
 		}
 
-		logs.LogDebug("Server properties: %s", c.serverProperties)
-		more, err := Is311OrMore(c.serverProperties["version"])
+		err = c.availableFeatures.SetVersion(serverProperties["version"])
 		if err != nil {
 			logs.LogWarn("Error checking server version: %s", err)
 		}
 
-		if serverProperties["version"] == "" || !more {
+		if serverProperties["version"] == "" || !c.availableFeatures.Is311OrMore() {
 			logs.LogInfo(
 				"Server version is less than 3.11.0, skipping command version exchange")
 		} else {

--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -213,7 +213,12 @@ func (c *Client) connect() error {
 		}
 
 		logs.LogDebug("Server properties: %s", c.serverProperties)
-		if serverProperties["version"] == "" {
+		more, err := Is311OrMore(c.serverProperties["version"])
+		if err != nil {
+			logs.LogWarn("Error checking server version: %s", err)
+		}
+
+		if serverProperties["version"] == "" || !more {
 			logs.LogInfo(
 				"Server version is less than 3.11.0, skipping command version exchange")
 		} else {

--- a/pkg/stream/utils.go
+++ b/pkg/stream/utils.go
@@ -3,8 +3,6 @@ package stream
 import (
 	"fmt"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/logs"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -58,71 +56,4 @@ func SetLevelInfo(value int8) {
 
 func containsOnlySpaces(input string) bool {
 	return len(input) > 0 && len(strings.TrimSpace(input)) == 0
-}
-
-//private static string ExtractVersion(string fullVersion)
-//{
-//const string Pattern = @"(\d+\.\d+\.\d+)";
-//var match = Regex.Match(fullVersion, Pattern);
-//
-//return match.Success
-//? match.Groups[1].Value
-//: string.Empty;
-//}
-
-func ExtractVersion(fullVersion string) string {
-	const pattern = `(\d+\.\d+\.\d+)`
-	re := regexp.MustCompile(pattern)
-	match := re.FindStringSubmatch(fullVersion)
-	if len(match) > 0 {
-		return match[1]
-	}
-	return ""
-}
-
-func Is311OrMore(version string) (bool, error) {
-	v := ExtractVersion(version)
-	compare, err := CompareSemver(v, "3.11.0")
-	if err != nil {
-		return false, err
-	}
-	return compare >= 0, nil
-}
-
-// CompareSemver compares two semantic version strings.
-// Returns -1 if v1 < v2, 1 if v1 > v2, and 0 if they are equal.
-func CompareSemver(v1, v2 string) (int, error) {
-	parseVersion := func(v string) ([]int, error) {
-		parts := strings.Split(v, ".")
-		if len(parts) != 3 {
-			return nil, fmt.Errorf("invalid semantic version: %s", v)
-		}
-		version := make([]int, 3)
-		for i, part := range parts {
-			num, err := strconv.Atoi(part)
-			if err != nil {
-				return nil, fmt.Errorf("invalid number in version: %s", part)
-			}
-			version[i] = num
-		}
-		return version, nil
-	}
-
-	v1Parts, err := parseVersion(v1)
-	if err != nil {
-		return 0, err
-	}
-	v2Parts, err := parseVersion(v2)
-	if err != nil {
-		return 0, err
-	}
-
-	for i := 0; i < 3; i++ {
-		if v1Parts[i] < v2Parts[i] {
-			return -1, nil
-		} else if v1Parts[i] > v2Parts[i] {
-			return 1, nil
-		}
-	}
-	return 0, nil
 }


### PR DESCRIPTION
Fixes: https://github.com/rabbitmq/rabbitmq-stream-go-client/issues/344 

When the `serverProperties["version"]` is not empty the client now checks the version. 
If the version is >=3.11 it is possible to enable the `exchangeVersion` function. 


Fixes another small bug when the [single active consumer is enabled](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/345/files#diff-4fb6ad931a13179f366870a7cc4500615ed0380fce0a7c6390f2e68bd553b24dL48) 


cc @hiimjako  


