### PR TITLE
chore: deprecate io/ioutil and rand.New

### DIFF
--- a/pkg/stream/aggregation.go
+++ b/pkg/stream/aggregation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pierrec/lz4"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/logs"
 	"io"
-	"io/ioutil"
 )
 
 const (
@@ -149,7 +148,7 @@ func (es compressGZIP) UnCompress(source *bufio.Reader, dataSize, uncompressedDa
 	/// headers ---> payload --> headers --> payload (compressed)
 
 	// Read in data.
-	uncompressedReader, err := ioutil.ReadAll(reader)
+	uncompressedReader, err := io.ReadAll(reader)
 	if err != nil {
 		logs.LogError("Error during reading buffer %s", err)
 	}
@@ -213,7 +212,7 @@ func (es compressSnappy) UnCompress(source *bufio.Reader, dataSize, uncompressed
 	/// headers ---> payload --> headers --> payload (compressed)
 
 	// Read in data.
-	uncompressedReader, err := ioutil.ReadAll(reader)
+	uncompressedReader, err := io.ReadAll(reader)
 	if err != nil {
 		logs.LogError("Error during reading buffer %s", err)
 	}
@@ -275,7 +274,7 @@ func (es compressLZ4) UnCompress(source *bufio.Reader, dataSize, uncompressedDat
 	/// headers ---> payload --> headers --> payload (compressed)
 
 	// Read in data.
-	uncompressedReader, err := ioutil.ReadAll(reader)
+	uncompressedReader, err := io.ReadAll(reader)
 	if err != nil {
 		logs.LogError("Error during reading buffer %s", err)
 	}
@@ -345,7 +344,7 @@ func (es compressZSTD) UnCompress(source *bufio.Reader, dataSize, uncompressedDa
 	/// headers ---> payload --> headers --> payload (compressed)
 
 	// Read in data.
-	uncompressedReader, err := ioutil.ReadAll(reader)
+	uncompressedReader, err := io.ReadAll(reader)
 	if err != nil {
 		logs.LogError("Error during reading buffer %s", err)
 	}

--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -755,8 +755,8 @@ func (c *Client) BrokerForConsumer(stream string) (*Broker, error) {
 		brokers = append(brokers, replica)
 	}
 
-	rand.Seed(time.Now().UnixNano())
-	n := rand.Intn(len(brokers))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	n := r.Intn(len(brokers))
 	return brokers[n], nil
 }
 

--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -125,8 +125,8 @@ func (env *Environment) newReconnectClient() (*Client, error) {
 		logs.LogError("Can't connect the locator client, error:%s, retry in %d milliseconds, broker: ", err, sleepTime, brokerUri)
 
 		time.Sleep(time.Duration(sleepTime) * time.Millisecond)
-		rand.Seed(time.Now().UnixNano())
-		n := rand.Intn(len(env.options.ConnectionParameters))
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		n := r.Intn(len(env.options.ConnectionParameters))
 		client = newClient("stream-locator", env.options.ConnectionParameters[n], env.options.TCPParameters,
 			env.options.SaslConfiguration, env.options.RPCTimeout)
 		tentatives = tentatives + 1


### PR DESCRIPTION
This PR aims to deprecate the usage of ioutil package and enahnce the usage of rand.New calls. 

No breaking changes.