### PR TITLE
Performance improvement on unconfirmed map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,8 @@ $(STATICCHECK):
 check: $(STATICCHECK)
 	$(STATICCHECK) ./pkg/stream
 
-GOMOCK ?= $(GOBIN)/mockgen
-GOMOCK_VERSION ?= v1.6.0
-$(GOMOCK):
-	go install github.com/golang/mock/mockgen@$(GOMOCK_VERSION)
-
-.PHONY: gomock
-gomock: $(GOMOCK)
-
 NUM_PROCS ?= 2
-TEST_TIMEOUT ?= 2m
+TEST_TIMEOUT ?= 3m
 test: vet fmt check
 	go run -mod=mod github.com/onsi/ginkgo/v2/ginkgo -r --procs=$(NUM_PROCS) --compilers=$(NUM_PROCS) \
 		--randomize-all --randomize-suites \

--- a/pkg/ha/ha_publisher.go
+++ b/pkg/ha/ha_publisher.go
@@ -63,7 +63,6 @@ type ReliableProducer struct {
 	producerOptions       *stream.ProducerOptions
 	count                 int32
 	confirmMessageHandler ConfirmMessageHandler
-	channelPublishConfirm stream.ChannelPublishConfirm
 	mutex                 *sync.Mutex
 	mutexStatus           *sync.Mutex
 	status                int
@@ -108,8 +107,7 @@ func (p *ReliableProducer) newProducer() error {
 
 		return err
 	}
-	p.channelPublishConfirm = producer.NotifyPublishConfirmation()
-	p.handlePublishConfirm(p.channelPublishConfirm)
+	p.handlePublishConfirm(producer.NotifyPublishConfirmation())
 	channelNotifyClose := producer.NotifyClose()
 	p.handleNotifyClose(channelNotifyClose)
 	p.producer = producer

--- a/pkg/stream/constants.go
+++ b/pkg/stream/constants.go
@@ -81,9 +81,8 @@ const (
 	responseCodeNoOffset                      = uint16(19)
 
 	/// responses out of protocol
-	closeChannel         = uint16(60)
-	connectionCloseError = uint16(61)
-	timeoutError         = uint16(62)
+	timeoutError = uint16(62)
+	entityClosed = uint16(63)
 
 	///
 	defaultSocketCallTimeout = 10 * time.Second
@@ -194,6 +193,9 @@ func lookErrorCode(errorCode uint16) error {
 		return AuthenticationFailureLoopbackError
 	case timeoutError:
 		return ConfirmationTimoutError
+	case entityClosed:
+		return AlreadyClosed
+
 	default:
 		{
 			logs.LogWarn("Error not handled %d", errorCode)

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -418,6 +418,14 @@ func (producer *Producer) BatchSend(batchMessages []message.StreamMessage) error
 	}
 	//
 
+	if producer.getStatus() == closed {
+		for _, msg := range messagesSequence {
+			m := producer.unConfirmed.extractWithError(msg.publishingId, entityClosed)
+			producer.sendConfirmationStatus([]*ConfirmationStatus{m})
+		}
+		return fmt.Errorf("producer id: %d closed", producer.id)
+	}
+
 	if totalBufferToSend+initBufferPublishSize > maxFrame {
 		// if the totalBufferToSend is greater than the requestedMaxFrameSize
 		// all the messages are unconfirmed

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -628,7 +628,6 @@ func (producer *Producer) close(reason Event) error {
 		logs.LogDebug("producer options is nil, the close will be ignored")
 		return nil
 	}
-	_, _ = producer.options.client.coordinator.ExtractProducerById(producer.id)
 
 	if !producer.options.client.socket.isOpen() {
 		return fmt.Errorf("tcp connection is closed")
@@ -638,6 +637,8 @@ func (producer *Producer) close(reason Event) error {
 	if reason.Reason == DeletePublisher {
 		_ = producer.options.client.deletePublisher(producer.id)
 	}
+
+	_, _ = producer.options.client.coordinator.ExtractProducerById(producer.id)
 
 	if producer.options.client.coordinator.ProducersCount() == 0 {
 		_ = producer.options.client.Close()

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -51,6 +51,15 @@ func (cs *ConfirmationStatus) GetErrorCode() uint16 {
 	return cs.errorCode
 }
 
+func (cs *ConfirmationStatus) updateStatus(errorCode uint16, confirmed bool) {
+	cs.confirmed = confirmed
+	if confirmed {
+		return
+	}
+	cs.errorCode = errorCode
+	cs.err = lookErrorCode(errorCode)
+}
+
 type messageSequence struct {
 	sourceMsg    message.StreamMessage
 	messageBytes []byte

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -195,10 +195,6 @@ func NewProducerOptions() *ProducerOptions {
 	}
 }
 
-func (producer *Producer) GetUnConfirmed() map[int64]*ConfirmationStatus {
-	return producer.unConfirmed.getAll()
-}
-
 func (po *ProducerOptions) isSubEntriesBatching() bool {
 	return po.SubEntrySize > 1
 }

--- a/pkg/stream/producer_test.go
+++ b/pkg/stream/producer_test.go
@@ -814,6 +814,15 @@ var _ = Describe("Streaming Producers", func() {
 		Expect(err.Error()).To(ContainSubstring("producer id: 0 closed"))
 	})
 
+	It("Can't bach send message if the producer is closed", func() {
+		producer, err := testEnvironment.NewProducer(testProducerStream, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(producer.Close()).NotTo(HaveOccurred())
+		err = producer.BatchSend([]message.StreamMessage{amqp.NewMessage(make([]byte, 50))})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("producer id: 0 closed"))
+	})
+
 })
 
 func testCompress(producer *Producer) {

--- a/pkg/stream/producer_test.go
+++ b/pkg/stream/producer_test.go
@@ -806,12 +806,12 @@ var _ = Describe("Streaming Producers", func() {
 	})
 
 	It("Can't send message if the producer is closed", func() {
-
 		producer, err := testEnvironment.NewProducer(testProducerStream, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(producer.Close()).NotTo(HaveOccurred())
 		err = producer.Send(amqp.NewMessage(make([]byte, 50)))
 		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("producer id: 0 closed"))
 	})
 
 })

--- a/pkg/stream/producer_test.go
+++ b/pkg/stream/producer_test.go
@@ -2,14 +2,15 @@ package stream
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 var _ = Describe("Streaming Producers", func() {
@@ -273,7 +274,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(14)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		Expect(producer.Close()).NotTo(HaveOccurred())
 	})
 
@@ -288,7 +289,7 @@ var _ = Describe("Streaming Producers", func() {
 		}
 
 		Expect(producer.Close()).NotTo(HaveOccurred())
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		Expect(producer.pendingSequencesQueue.IsEmpty()).To(Equal(true))
 	})
 
@@ -337,7 +338,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).WithPolling(300*time.Millisecond).Should(Equal(int32(101)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		Expect(producer.Close()).NotTo(HaveOccurred())
 		// in this case must raise an error since the producer is closed
 		Expect(producer.Close()).To(HaveOccurred())
@@ -389,7 +390,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(101)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		Expect(producer.Close()).NotTo(HaveOccurred())
 
 	})
@@ -422,7 +423,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(10)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		Expect(producer.Close()).NotTo(HaveOccurred())
 	})
 
@@ -621,7 +622,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(232)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 
 		// same test above but using batch Send
 		var arr []message.StreamMessage
@@ -639,7 +640,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(12*20)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 
 		Expect(producer.Close()).NotTo(HaveOccurred())
 
@@ -753,7 +754,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(501)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		atomic.StoreInt32(&messagesConfirmed, 0)
 
 		for z := 0; z < 501; z++ {
@@ -766,7 +767,7 @@ var _ = Describe("Streaming Producers", func() {
 		}, 5*time.Second).Should(Equal(int32(501*5)),
 			"confirm should receive same messages Send by producer")
 
-		Expect(producer.lenUnConfirmed()).To(Equal(0))
+		Expect(producer.unConfirmed.size()).To(Equal(0))
 		Expect(producer.Close()).NotTo(HaveOccurred())
 	})
 
@@ -776,7 +777,7 @@ var _ = Describe("Streaming Producers", func() {
 				SetSubEntrySize(33).SetCompression(Compression{}.Gzip()))
 		Expect(err).NotTo(HaveOccurred())
 		testCompress(producerGZIP)
-		Expect(producerGZIP.lenUnConfirmed()).To(Equal(0))
+		Expect(producerGZIP.unConfirmed.size()).To(Equal(0))
 		Expect(producerGZIP.Close()).NotTo(HaveOccurred())
 
 		producerLz4, err := testEnvironment.NewProducer(testProducerStream,
@@ -784,7 +785,7 @@ var _ = Describe("Streaming Producers", func() {
 				SetSubEntrySize(55).SetCompression(Compression{}.Lz4()))
 		Expect(err).NotTo(HaveOccurred())
 		testCompress(producerLz4)
-		Expect(producerLz4.lenUnConfirmed()).To(Equal(0))
+		Expect(producerLz4.unConfirmed.size()).To(Equal(0))
 		Expect(producerLz4.Close()).NotTo(HaveOccurred())
 
 		producerSnappy, err := testEnvironment.NewProducer(testProducerStream,
@@ -792,7 +793,7 @@ var _ = Describe("Streaming Producers", func() {
 				SetSubEntrySize(666).SetCompression(Compression{}.Snappy()))
 		Expect(err).NotTo(HaveOccurred())
 		testCompress(producerSnappy)
-		Expect(producerSnappy.lenUnConfirmed()).To(Equal(0))
+		Expect(producerSnappy.unConfirmed.size()).To(Equal(0))
 		Expect(producerSnappy.Close()).NotTo(HaveOccurred())
 
 		producerZstd, err := testEnvironment.NewProducer(testProducerStream,
@@ -800,7 +801,7 @@ var _ = Describe("Streaming Producers", func() {
 				SetSubEntrySize(98).SetCompression(Compression{}.Zstd()))
 		Expect(err).NotTo(HaveOccurred())
 		testCompress(producerZstd)
-		Expect(producerZstd.lenUnConfirmed()).To(Equal(0))
+		Expect(producerZstd.unConfirmed.size()).To(Equal(0))
 		Expect(producerZstd.Close()).NotTo(HaveOccurred())
 
 	})
@@ -844,7 +845,7 @@ func testCompress(producer *Producer) {
 	}, 5*time.Second).Should(Equal(int32(457)),
 		"confirm should receive same messages Send by producer")
 
-	Expect(producer.lenUnConfirmed()).To(Equal(0))
+	Expect(producer.unConfirmed.size()).To(Equal(0))
 	atomic.StoreInt32(&messagesConfirmed, 0)
 
 	for z := 0; z < 457; z++ {
@@ -906,7 +907,7 @@ func verifyProducerSent(producer *Producer, confirmationReceived *int32, message
 	}, 10*time.Second, 1*time.Second).Should(Equal(int32(messageSent)),
 		"confirm should receive same messages Send by producer")
 
-	Expect(producer.lenUnConfirmed()).To(Equal(0))
+	Expect(producer.unConfirmed.size()).To(Equal(0))
 }
 
 func runConcurrentlyAndWaitTillAllDone(threadCount int, wg *sync.WaitGroup, runner func(int)) {

--- a/pkg/stream/producer_unconfirmed.go
+++ b/pkg/stream/producer_unconfirmed.go
@@ -3,8 +3,6 @@ package stream
 import (
 	"sync"
 	"time"
-
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 )
 
 // unConfirmed is a structure that holds unconfirmed messages
@@ -32,15 +30,16 @@ func newUnConfirmed() *unConfirmed {
 	return r
 }
 
-func (u *unConfirmed) addFromSequence(message *messageSequence, source *message.StreamMessage, producerID uint8) {
-
+func (u *unConfirmed) addFromSequences(messages []*messageSequence, producerID uint8) {
 	u.mutexMessageMap.Lock()
-	u.messages[message.publishingId] = &ConfirmationStatus{
-		inserted:     time.Now(),
-		message:      *source,
-		producerID:   producerID,
-		publishingId: message.publishingId,
-		confirmed:    false,
+	for _, msgSeq := range messages {
+		u.messages[msgSeq.publishingId] = &ConfirmationStatus{
+			inserted:     time.Now(),
+			message:      msgSeq.sourceMsg,
+			producerID:   producerID,
+			publishingId: msgSeq.publishingId,
+			confirmed:    false,
+		}
 	}
 	u.mutexMessageMap.Unlock()
 }

--- a/pkg/stream/producer_unconfirmed.go
+++ b/pkg/stream/producer_unconfirmed.go
@@ -1,52 +1,20 @@
 package stream
 
 import (
-	"container/heap"
 	"sync"
 	"time"
 )
 
-type priorityMessage struct {
-	*ConfirmationStatus
-	index int
-}
-
-// priorityQueue implements heap.Interface
-type priorityQueue []*priorityMessage
-
-func (pq priorityQueue) Len() int { return len(pq) }
-
-func (pq priorityQueue) Less(i, j int) bool {
-	// Earlier timestamps have higher priority
-	return pq[i].inserted.Before(pq[j].inserted)
-}
-
-func (pq priorityQueue) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
-}
-
-func (pq *priorityQueue) Push(x interface{}) {
-	n := len(*pq)
-	item := x.(*priorityMessage)
-	item.index = n
-	*pq = append(*pq, item)
-}
-
-func (pq *priorityQueue) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil
-	item.index = -1
-	*pq = old[0 : n-1]
-	return item
-}
-
+// unConfirmed is a structure that holds unconfirmed messages
+// And unconfirmed message is a message that has been sent to the broker but not yet confirmed,
+// and it is added to the unConfirmed structure as soon is possible when
+//
+//	the Send() or BatchSend() method is called
+//
+// The confirmation status is updated when the confirmation is received from the broker (see server_frame.go)
+// or due of timeout. The Timeout is configurable, and it is calculated client side.
 type unConfirmed struct {
-	messages        map[int64]*priorityMessage
-	timeoutQueue    priorityQueue
+	messages        map[int64]*ConfirmationStatus
 	mutexMessageMap sync.RWMutex
 }
 
@@ -54,11 +22,9 @@ const DefaultUnconfirmedSize = 10_000
 
 func newUnConfirmed() *unConfirmed {
 	r := &unConfirmed{
-		messages:        make(map[int64]*priorityMessage, DefaultUnconfirmedSize),
-		timeoutQueue:    make(priorityQueue, 0, DefaultUnconfirmedSize),
+		messages:        make(map[int64]*ConfirmationStatus, DefaultUnconfirmedSize),
 		mutexMessageMap: sync.RWMutex{},
 	}
-	heap.Init(&r.timeoutQueue)
 	return r
 }
 
@@ -67,30 +33,23 @@ func (u *unConfirmed) addFromSequences(messages []*messageSequence, producerID u
 	defer u.mutexMessageMap.Unlock()
 
 	for _, msgSeq := range messages {
-		pm := &priorityMessage{
-			ConfirmationStatus: &ConfirmationStatus{
-				inserted:     time.Now(),
-				message:      msgSeq.sourceMsg,
-				producerID:   producerID,
-				publishingId: msgSeq.publishingId,
-				confirmed:    false,
-			},
+		u.messages[msgSeq.publishingId] = &ConfirmationStatus{
+			inserted:     time.Now(),
+			message:      msgSeq.sourceMsg,
+			producerID:   producerID,
+			publishingId: msgSeq.publishingId,
+			confirmed:    false,
 		}
-		u.messages[msgSeq.publishingId] = pm
-		heap.Push(&u.timeoutQueue, pm)
+
 	}
 }
 
 func (u *unConfirmed) link(from int64, to int64) {
 	u.mutexMessageMap.Lock()
 	defer u.mutexMessageMap.Unlock()
-
-	fromMsg := u.messages[from]
-	if fromMsg != nil {
-		toMsg := u.messages[to]
-		if toMsg != nil {
-			fromMsg.linkedTo = append(fromMsg.linkedTo, toMsg.ConfirmationStatus)
-		}
+	r := u.messages[from]
+	if r != nil {
+		r.linkedTo = append(r.linkedTo, u.messages[to])
 	}
 }
 
@@ -100,14 +59,16 @@ func (u *unConfirmed) extractWithConfirms(ids []int64) []*ConfirmationStatus {
 
 	res := make([]*ConfirmationStatus, 0, len(ids))
 	for _, v := range ids {
-		if msg := u.extract(v, 0, true); msg != nil {
-			res = append(res, msg)
-			if msg.linkedTo != nil {
-				res = append(res, msg.linkedTo...)
+		m := u.extract(v, 0, true)
+		if m != nil {
+			res = append(res, m)
+			if m.linkedTo != nil {
+				res = append(res, m.linkedTo...)
 			}
 		}
 	}
 	return res
+
 }
 
 func (u *unConfirmed) extractWithError(id int64, errorCode uint16) *ConfirmationStatus {
@@ -117,53 +78,38 @@ func (u *unConfirmed) extractWithError(id int64, errorCode uint16) *Confirmation
 }
 
 func (u *unConfirmed) extract(id int64, errorCode uint16, confirmed bool) *ConfirmationStatus {
-	pm := u.messages[id]
-	if pm == nil {
-		return nil
-	}
+	rootMessage := u.messages[id]
+	if rootMessage != nil {
+		u.updateStatus(rootMessage, errorCode, confirmed)
 
-	rootMessage := pm.ConfirmationStatus
-	rootMessage.updateStatus(errorCode, confirmed)
-
-	for _, linkedMessage := range rootMessage.linkedTo {
-		linkedMessage.updateStatus(errorCode, confirmed)
-		if linkedPm := u.messages[linkedMessage.publishingId]; linkedPm != nil {
-			// Remove from priority queue if exists
-			if linkedPm.index != -1 {
-				heap.Remove(&u.timeoutQueue, linkedPm.index)
-			}
+		for _, linkedMessage := range rootMessage.linkedTo {
+			u.updateStatus(linkedMessage, errorCode, confirmed)
 			delete(u.messages, linkedMessage.publishingId)
 		}
+		delete(u.messages, id)
 	}
-
-	// Remove from priority queue if exists
-	if pm.index != -1 {
-		heap.Remove(&u.timeoutQueue, pm.index)
-	}
-	delete(u.messages, id)
-
 	return rootMessage
+}
+
+func (u *unConfirmed) updateStatus(rootMessage *ConfirmationStatus, errorCode uint16, confirmed bool) {
+	rootMessage.confirmed = confirmed
+	if confirmed {
+		return
+	}
+	rootMessage.errorCode = errorCode
+	rootMessage.err = lookErrorCode(errorCode)
 }
 
 func (u *unConfirmed) extractWithTimeOut(timeout time.Duration) []*ConfirmationStatus {
 	u.mutexMessageMap.Lock()
 	defer u.mutexMessageMap.Unlock()
-
 	var res []*ConfirmationStatus
-	now := time.Now()
-
-	for u.timeoutQueue.Len() > 0 {
-		pm := u.timeoutQueue[0]
-		if now.Sub(pm.inserted) < timeout {
-			break
-		}
-
-		heap.Pop(&u.timeoutQueue)
-		if msg := u.extract(pm.publishingId, timeoutError, false); msg != nil {
-			res = append(res, msg)
+	for _, v := range u.messages {
+		if time.Since(v.inserted) > timeout {
+			v := u.extract(v.publishingId, timeoutError, false)
+			res = append(res, v)
 		}
 	}
-
 	return res
 }
 

--- a/pkg/stream/producer_unconfirmed.go
+++ b/pkg/stream/producer_unconfirmed.go
@@ -98,7 +98,7 @@ func (u *unConfirmed) extractWithConfirms(ids []int64) []*ConfirmationStatus {
 	u.mutexMessageMap.Lock()
 	defer u.mutexMessageMap.Unlock()
 
-	var res []*ConfirmationStatus
+	res := make([]*ConfirmationStatus, 0, len(ids))
 	for _, v := range ids {
 		if msg := u.extract(v, 0, true); msg != nil {
 			res = append(res, msg)

--- a/pkg/stream/producer_unconfirmed.go
+++ b/pkg/stream/producer_unconfirmed.go
@@ -1,9 +1,10 @@
 package stream
 
 import (
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 	"sync"
 	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 )
 
 // unConfirmed is a structure that holds unconfirmed messages
@@ -105,7 +106,7 @@ func (u *unConfirmed) extractWithTimeOut(timeout time.Duration) []*ConfirmationS
 	defer u.mutexMessageMap.Unlock()
 	var res []*ConfirmationStatus
 	for _, v := range u.messages {
-		if time.Since(v.inserted) > timeout {
+		if time.Since(v.inserted) >= timeout {
 			v := u.extract(v.publishingId, timeoutError, false)
 			res = append(res, v)
 		}

--- a/pkg/stream/producer_unconfirmed.go
+++ b/pkg/stream/producer_unconfirmed.go
@@ -123,10 +123,10 @@ func (u *unConfirmed) extract(id int64, errorCode uint16, confirmed bool) *Confi
 	}
 
 	rootMessage := pm.ConfirmationStatus
-	u.updateStatus(rootMessage, errorCode, confirmed)
+	rootMessage.updateStatus(errorCode, confirmed)
 
 	for _, linkedMessage := range rootMessage.linkedTo {
-		u.updateStatus(linkedMessage, errorCode, confirmed)
+		linkedMessage.updateStatus(errorCode, confirmed)
 		if linkedPm := u.messages[linkedMessage.publishingId]; linkedPm != nil {
 			// Remove from priority queue if exists
 			if linkedPm.index != -1 {
@@ -143,15 +143,6 @@ func (u *unConfirmed) extract(id int64, errorCode uint16, confirmed bool) *Confi
 	delete(u.messages, id)
 
 	return rootMessage
-}
-
-func (u *unConfirmed) updateStatus(rootMessage *ConfirmationStatus, errorCode uint16, confirmed bool) {
-	rootMessage.confirmed = confirmed
-	if confirmed {
-		return
-	}
-	rootMessage.errorCode = errorCode
-	rootMessage.err = lookErrorCode(errorCode)
 }
 
 func (u *unConfirmed) extractWithTimeOut(timeout time.Duration) []*ConfirmationStatus {

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -255,23 +255,11 @@ func (c *Client) handleConfirm(readProtocol *ReaderProtocol, r *bufio.Reader) in
 	// even the producer is not found we need to read the publishingId
 	// to empty the buffer.
 	// The producer here could not exist because the producer is closed before the confirmations are received
-	//var unConfirmedRecv []*ConfirmationStatus
+
 	var arraySeq []int64
 	for publishingIdCount != 0 {
 		seq := readInt64(r)
 		arraySeq = append(arraySeq, seq)
-		//if producerFound {
-		//	m := producer.unConfirmed.extractWithConfirm(seq)
-		//	if m != nil {
-		//		unConfirmedRecv = append(unConfirmedRecv, m)
-		//
-		//		// in case of sub-batch entry the client receives only
-		//		// one publishingId (or sequence)
-		//		// so the other messages are confirmed using the linkedTo
-		//		unConfirmedRecv = append(unConfirmedRecv, m.linkedTo...)
-		//	}
-		//}
-
 		publishingIdCount--
 	}
 

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -256,7 +256,7 @@ func (c *Client) handleConfirm(readProtocol *ReaderProtocol, r *bufio.Reader) in
 	// to empty the buffer.
 	// The producer here could not exist because the producer is closed before the confirmations are received
 
-	var arraySeq []int64
+	arraySeq := make([]int64, 0, publishingIdCount)
 	for publishingIdCount != 0 {
 		seq := readInt64(r)
 		arraySeq = append(arraySeq, seq)


### PR DESCRIPTION
This is a sub-branch of check_close_during_send, so please ensure that [PR #372](https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/372) is merged first.

This PR introduces performance improvements by leveraging slice preallocation and reducing the average size of the unConfirmed map, which now only stores the currently in-flight messages.

Note: Additionally, I identified the root cause of the performance degradation observed in the client under high traffic or client reconnections in cloud environments. This issue appears to be related to [Issue #293](https://github.com/rabbitmq/rabbitmq-stream-go-client/issues/293) and is associated with the default TCP socket settings. I suspect this is OS-related, as it manifests on Linux (tested on an AWS cluster with ARM64 nodes running Linux). Again this was solved setting in the stream `SetWriteBuffer(-1)` and `SetReadBuffer(-1)`.
