### PR TITLE
Fix handling and storing offset by timestamp

### DIFF
--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -926,7 +926,7 @@ func (c *Client) declareSubscriber(streamName string,
 	// copy the option offset to the consumer offset
 	// the option.offset won't change ( in case we need to retrive the original configuration)
 	// consumer.current offset will be moved when reading
-	if !options.IsSingleActiveConsumerEnabled() {
+	if !options.IsSingleActiveConsumerEnabled() && options.Offset.isOffset() {
 		consumer.setCurrentOffset(options.Offset.offset)
 	}
 

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -588,7 +588,7 @@ func (c *Client) handleConsumerUpdate(readProtocol *ReaderProtocol, r *bufio.Rea
 		isActive == 1)
 	consumer.options.SingleActiveConsumer.offsetSpecification = responseOff
 
-	if isActive == 1 {
+	if isActive == 1 && responseOff.isOffset() {
 		consumer.setCurrentOffset(responseOff.offset)
 	}
 


### PR DESCRIPTION
Problem:

Sometimes the timestamp value can be written as an offset in rabbitmq, which freezes message consumption. 

**Real case**: You add a new consumer to an existing stream for which the offset is not yet set. You do not want to reread all messages, so you specify -1 min. If there are no messages for a certain time and automatic flush is triggered, this timestamp value will be written as the offset.

As a summary, based on the code in the library and the stream protocol, it looks like the method `consumer.setCurrentOffset` should only be called with a typeOffset value.
