### PR TITLE
Fix producers reconnection deadlock

### DIFF
--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -510,7 +510,6 @@ func (cc *environmentCoordinator) maybeCleanClients() {
 }
 
 func (c *Client) maybeCleanProducers(streamName string) {
-	c.mutex.Lock()
 	for pidx, producer := range c.coordinator.Producers() {
 		if producer.(*Producer).GetStreamName() == streamName {
 			err := c.coordinator.RemoveProducerById(pidx.(uint8), Event{
@@ -525,8 +524,6 @@ func (c *Client) maybeCleanProducers(streamName string) {
 			}
 		}
 	}
-	c.mutex.Unlock()
-
 }
 
 func (c *Client) maybeCleanConsumers(streamName string) {

--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -527,8 +527,7 @@ func (c *Client) maybeCleanProducers(streamName string) {
 }
 
 func (c *Client) maybeCleanConsumers(streamName string) {
-	c.mutex.Lock()
-	for pidx, consumer := range c.coordinator.consumers {
+	for pidx, consumer := range c.coordinator.GetConsumers() {
 		if consumer.(*Consumer).options.streamName == streamName {
 			err := c.coordinator.RemoveConsumerById(pidx.(uint8), Event{
 				Command:    CommandMetadataUpdate,
@@ -542,7 +541,6 @@ func (c *Client) maybeCleanConsumers(streamName string) {
 			}
 		}
 	}
-	c.mutex.Unlock()
 }
 
 func (cc *environmentCoordinator) newProducer(leader *Broker, tcpParameters *TCPParameters, saslConfiguration *SaslConfiguration, streamName string, options *ProducerOptions, rpcTimeout time.Duration, cleanUp func()) (*Producer, error) {


### PR DESCRIPTION
A potential **deadlock** issue was identified in the function when handling changes in stream metadata. This issue occurs when the stream members are updated (e.g., disabling or modifying replicas). The deadlock caused execution to hang indefinitely, leaving publisher disconnected

#### How the Issue Was Discovered:
To reproduce the issue:
- A new test, **`should reconnect to the same partition after a close event`**, was introduced.
- The test successfully replicates the failure by simulating metadata updates and validating the ability of producers to reconnect to a specific partition after a clean-up operation.


#### Impact of the Issue:
- **When did it happen?**
    - This issue was triggered when stream metadata was changed, such as updates to stream replicas.

- **How did the application behave?**
    - The application ran without restrictions with errors during publishing, but the reconnect is not established
    - In the RabbitMQ Management UI, the consumer was visibly disconnected but was not recreated by the application.

- **Severity Level:**
    - The issue is **critical**, as it blocks RabbitMQ updates in production, where disabling a replica can cause a cascading failure of publisher connections. This poses a significant risk to high-availability implementations of RabbitMQ.

#### Fix Implemented:
- Removed unnecessary mutex locking in the method to prevent the possibility of a deadlock scenario. `maybeCleanProducers`

**Step-by-step description of the problem**
1. **Thread 1**: `maybeCleanConsumers` locks client mutex [pkg/stream/environment.go:513](https://github.com/rabbitmq/rabbitmq-stream-go-client/blob/main/pkg/stream/environment.go#L513)
2. **Thread 1**: `c.coordinator.RemoveConsumerById` triggers  signal to producers closeHandler  function [pkg/stream/producer.go:641](https://github.com/rabbitmq/rabbitmq-stream-go-client/blob/main/pkg/stream/producer.go#L641)
3.  **Thread 1**:`closeHandler` triggers `partitionCloseEvent` that the client can handle and try to reconnect (as in test)
4. **Thread 2**:client's reconnection call (from test) `event.Context.ConnectPartition` trigger [environmentCoordinator mutex.Lock](https://github.com/rabbitmq/rabbitmq-stream-go-client/blob/main/pkg/stream/environment.go#L552) 
5.  **Thread 2**: [clientResult.connect()](https://github.com/rabbitmq/rabbitmq-stream-go-client/blob/main/pkg/stream/environment.go#L573) triggers clients mutex.Lock, but it is already locked on step 1
6. **Thread 1**:  calls [coordinator.maybeCleanClients() in producers cleanUp function](https://github.com/rabbitmq/rabbitmq-stream-go-client/blob/main/pkg/stream/environment.go#L706) and tries to [lock producersEnvironment mutex](https://github.com/rabbitmq/rabbitmq-stream-go-client/blob/main/pkg/stream/environment.go#L500), but it is already locked on step 4 by Thread 2
7. Thread 1 is waiting  producersEnvironment's mutex that blocked Thread 2 and Thread2 is waiting client's mutex that blocked Thread 1 - we got deadlock
