### PR TITLE
Handle socket errors

### DIFF
--- a/pkg/stream/aggregation.go
+++ b/pkg/stream/aggregation.go
@@ -5,11 +5,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"io"
+
 	"github.com/golang/snappy"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/logs"
-	"io"
 )
 
 const (
@@ -64,12 +65,11 @@ type subEntries struct {
 }
 
 type iCompress interface {
-	Compress(subEntries *subEntries)
+	Compress(subEntries *subEntries) error
 	UnCompress(source *bufio.Reader, dataSize, uncompressedDataSize uint32) *bufio.Reader
 }
 
 func compressByValue(value byte) iCompress {
-
 	switch value {
 	case GZIP:
 		return compressGZIP{}
@@ -84,10 +84,9 @@ func compressByValue(value byte) iCompress {
 	return compressNONE{}
 }
 
-type compressNONE struct {
-}
+type compressNONE struct{}
 
-func (es compressNONE) Compress(subEntries *subEntries) {
+func (es compressNONE) Compress(subEntries *subEntries) error {
 	for _, entry := range subEntries.items {
 		var tmp bytes.Buffer
 		for _, msg := range entry.messages {
@@ -98,6 +97,8 @@ func (es compressNONE) Compress(subEntries *subEntries) {
 		entry.sizeInBytes += len(entry.dataInBytes)
 		subEntries.totalSizeInBytes += len(entry.dataInBytes)
 	}
+
+	return nil
 }
 
 func (es compressNONE) UnCompress(source *bufio.Reader, _, _ uint32) *bufio.Reader {
@@ -107,25 +108,32 @@ func (es compressNONE) UnCompress(source *bufio.Reader, _, _ uint32) *bufio.Read
 type compressGZIP struct {
 }
 
-func (es compressGZIP) Compress(subEntries *subEntries) {
+func (es compressGZIP) Compress(subEntries *subEntries) error {
 	for _, entry := range subEntries.items {
 		var tmp bytes.Buffer
 		w := gzip.NewWriter(&tmp)
+
 		for _, msg := range entry.messages {
-			size := len(msg.messageBytes)
-			//w.Write(bytesFromInt((uint32(size) >> 24) & 0xFF))
-			//w.Write(bytesFromInt((uint32(size) >> 16) & 0xFF))
-			//w.Write(bytesFromInt((uint32(size) >> 8) & 0xFF))
-			//w.Write(bytesFromInt((uint32(size) >> 0) & 0xFF))
-			w.Write(bytesFromInt(uint32(size)))
-			w.Write(msg.messageBytes)
+			prefixedMsg := bytesLenghPrefixed(msg.messageBytes)
+			if _, err := w.Write(prefixedMsg); err != nil {
+				return fmt.Errorf("failed to write message size to gzip writer: %w", err)
+			}
 		}
-		w.Flush()
-		w.Close()
+
+		if err := w.Flush(); err != nil {
+			return fmt.Errorf("failed to flush gzip writer: %w", err)
+		}
+
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("failed to close gzip writer: %w", err)
+		}
+
 		entry.sizeInBytes += len(tmp.Bytes())
 		entry.dataInBytes = tmp.Bytes()
 		subEntries.totalSizeInBytes += len(tmp.Bytes())
 	}
+
+	return nil
 }
 
 func (es compressGZIP) UnCompress(source *bufio.Reader, dataSize, uncompressedDataSize uint32) *bufio.Reader {
@@ -161,36 +169,33 @@ func (es compressGZIP) UnCompress(source *bufio.Reader, dataSize, uncompressedDa
 	return bufio.NewReader(bytes.NewReader(uncompressedReader))
 }
 
-type compressSnappy struct {
-}
+type compressSnappy struct{}
 
-func (es compressSnappy) Compress(subEntries *subEntries) {
+func (es compressSnappy) Compress(subEntries *subEntries) error {
 	for _, entry := range subEntries.items {
 		var tmp bytes.Buffer
 		w := snappy.NewBufferedWriter(&tmp)
 		for _, msg := range entry.messages {
-			size := len(msg.messageBytes)
-			if _, err := w.Write(bytesFromInt(uint32(size))); err != nil {
-				logs.LogError("Error compressing with Snappy %v", err)
-				//return err  // TODO we should return error if we cannot compress
-			}
-			if _, err := w.Write(msg.messageBytes); err != nil {
-				logs.LogError("Error compressing with Snappy %v", err)
-				//return err  // TODO we should return error if we cannot compress
+			prefixedMsg := bytesLenghPrefixed(msg.messageBytes)
+			if _, err := w.Write(prefixedMsg); err != nil {
+				return fmt.Errorf("failed to write message size to snappy writer: %w", err)
 			}
 		}
+
 		if err := w.Flush(); err != nil {
-			logs.LogError("Error compressing with Snappy %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("failed to flush snappy writer: %w", err)
 		}
+
 		if err := w.Close(); err != nil {
-			logs.LogError("Error compressing with Snappy %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("failed to close snappy writer: %w", err)
 		}
+
 		entry.sizeInBytes += len(tmp.Bytes())
 		entry.dataInBytes = tmp.Bytes()
 		subEntries.totalSizeInBytes += len(tmp.Bytes())
 	}
+
+	return nil
 }
 
 func (es compressSnappy) UnCompress(source *bufio.Reader, dataSize, uncompressedDataSize uint32) *bufio.Reader {
@@ -226,36 +231,34 @@ func (es compressSnappy) UnCompress(source *bufio.Reader, dataSize, uncompressed
 
 }
 
-type compressLZ4 struct {
-}
+type compressLZ4 struct{}
 
-func (es compressLZ4) Compress(subEntries *subEntries) {
+func (es compressLZ4) Compress(subEntries *subEntries) error {
 	for _, entry := range subEntries.items {
 		var tmp bytes.Buffer
 		w := lz4.NewWriter(&tmp)
+
 		for _, msg := range entry.messages {
-			size := len(msg.messageBytes)
-			if _, err := w.Write(bytesFromInt(uint32(size))); err != nil {
-				logs.LogError("Error compressing with LZ4 %v", err)
-				//return err  // TODO we should return error if we cannot compress
-			}
-			if _, err := w.Write(msg.messageBytes); err != nil {
-				logs.LogError("Error compressing with LZ4 %v", err)
-				//return err  // TODO we should return error if we cannot compress
+			prefixedMsg := bytesLenghPrefixed(msg.messageBytes)
+			if _, err := w.Write(prefixedMsg); err != nil {
+				return fmt.Errorf("failed to write message size to LZ4 writer: %w", err)
 			}
 		}
+
 		if err := w.Flush(); err != nil {
-			logs.LogError("Error compressing with LZ4 %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("failed to flush LZ4 writer: %w", err)
 		}
+
 		if err := w.Close(); err != nil {
-			logs.LogError("Error compressing with LZ4 %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("failed to close LZ4 writer: %w", err)
 		}
+
 		entry.sizeInBytes += len(tmp.Bytes())
 		entry.dataInBytes = tmp.Bytes()
 		subEntries.totalSizeInBytes += len(tmp.Bytes())
 	}
+
+	return nil
 }
 
 func (es compressLZ4) UnCompress(source *bufio.Reader, dataSize, uncompressedDataSize uint32) *bufio.Reader {
@@ -288,41 +291,37 @@ func (es compressLZ4) UnCompress(source *bufio.Reader, dataSize, uncompressedDat
 
 }
 
-type compressZSTD struct {
-}
+type compressZSTD struct{}
 
-func (es compressZSTD) Compress(subEntries *subEntries) {
+func (es compressZSTD) Compress(subEntries *subEntries) error {
 	for _, entry := range subEntries.items {
 		var tmp bytes.Buffer
 		w, err := zstd.NewWriter(&tmp)
 		if err != nil {
-			logs.LogError("Error creating ZSTD compression algorithm writer %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("error creating ZSTD compression algorithm writer %w", err)
 		}
 
 		for _, msg := range entry.messages {
-			size := len(msg.messageBytes)
-			if _, err := w.Write(bytesFromInt(uint32(size))); err != nil {
-				logs.LogError("Error compressing with ZSTD %v", err)
-				//return err  // TODO we should return error if we cannot compress
-			}
-			if _, err := w.Write(msg.messageBytes); err != nil {
-				logs.LogError("Error compressing with ZSTD %v", err)
-				//return err  // TODO we should return error if we cannot compress
+			prefixedMsg := bytesLenghPrefixed(msg.messageBytes)
+			if _, err := w.Write(prefixedMsg); err != nil {
+				return fmt.Errorf("failed to write message size to ZSTD writer: %w", err)
 			}
 		}
+
 		if err := w.Flush(); err != nil {
-			logs.LogError("Error compressing with ZSTD %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("failed to flush ZSTD writer: %w", err)
 		}
+
 		if err := w.Close(); err != nil {
-			logs.LogError("Error compressing with ZSTD %v", err)
-			//return err  // TODO we should return error if we cannot compress
+			return fmt.Errorf("failed to close ZSTD writer: %w", err)
 		}
+
 		entry.sizeInBytes += len(tmp.Bytes())
 		entry.dataInBytes = tmp.Bytes()
 		subEntries.totalSizeInBytes += len(tmp.Bytes())
 	}
+
+	return nil
 }
 
 func (es compressZSTD) UnCompress(source *bufio.Reader, dataSize, uncompressedDataSize uint32) *bufio.Reader {

--- a/pkg/stream/aggregation_test.go
+++ b/pkg/stream/aggregation_test.go
@@ -3,12 +3,12 @@ package stream
 import (
 	"bufio"
 	"bytes"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Compression algorithms", func() {
-
 	var entries *subEntries
 
 	BeforeEach(func() {
@@ -35,46 +35,48 @@ var _ = Describe("Compression algorithms", func() {
 	})
 
 	It("NONE", func() {
-		compressNONE{}.Compress(entries)
+		err := compressNONE{}.Compress(entries)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(entries.totalSizeInBytes).To(Equal(entries.items[0].sizeInBytes))
 		Expect(entries.totalSizeInBytes).To(Equal(entries.items[0].unCompressedSize))
-
 	})
 
 	It("GZIP", func() {
 		gzip := compressGZIP{}
-		gzip.Compress(entries)
+		err := gzip.Compress(entries)
+		Expect(err).NotTo(HaveOccurred())
 		verifyCompression(gzip, entries)
-
 	})
 
 	It("SNAPPY", func() {
 		snappy := compressSnappy{}
-		snappy.Compress(entries)
+		err := snappy.Compress(entries)
+		Expect(err).NotTo(HaveOccurred())
 		verifyCompression(snappy, entries)
 	})
 
 	It("LZ4", func() {
 		lz4 := compressLZ4{}
-		lz4.Compress(entries)
+		err := lz4.Compress(entries)
+		Expect(err).NotTo(HaveOccurred())
 		verifyCompression(lz4, entries)
 	})
 
 	It("ZSTD", func() {
 		zstd := compressZSTD{}
-		zstd.Compress(entries)
+		err := zstd.Compress(entries)
+		Expect(err).NotTo(HaveOccurred())
 		verifyCompression(zstd, entries)
 	})
-
 })
 
 func verifyCompression(algo iCompress, subEntries *subEntries) {
-
 	Expect(subEntries.totalSizeInBytes).To(SatisfyAll(BeNumerically("<", subEntries.items[0].unCompressedSize)))
 	Expect(subEntries.totalSizeInBytes).To(Equal(subEntries.items[0].sizeInBytes))
 
 	bufferReader := bytes.NewReader(subEntries.items[0].dataInBytes)
-	algo.UnCompress(bufio.NewReader(bufferReader),
+	_, err := algo.UnCompress(bufio.NewReader(bufferReader),
 		uint32(subEntries.totalSizeInBytes), uint32(subEntries.items[0].unCompressedSize))
 
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/pkg/stream/buffer_writer.go
+++ b/pkg/stream/buffer_writer.go
@@ -80,11 +80,6 @@ func writeBUInt(inputBuff *bufio.Writer, value uint32) {
 	inputBuff.Write(buff)
 }
 
-func bytesFromInt(value uint32) []byte {
-	var buff = make([]byte, 4)
-	binary.BigEndian.PutUint32(buff, value)
-	return buff
-}
 func writeString(inputBuff *bytes.Buffer, value string) {
 	writeUShort(inputBuff, uint16(len(value)))
 	inputBuff.Write([]byte(value))
@@ -156,4 +151,14 @@ func sizeOfMapStringString(mapString map[string]string) int {
 		size += 2 + len(k) + 2 + len(v)
 	}
 	return size
+}
+
+func bytesLenghPrefixed(msg []byte) []byte {
+	size := len(msg)
+	buff := make([]byte, 4+size)
+
+	binary.BigEndian.PutUint32(buff, uint32(size))
+	copy(buff[4:], msg)
+
+	return buff
 }

--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -470,7 +470,7 @@ func (c *Client) closeHartBeat() {
 
 }
 
-func (c *Client) Close() error {
+func (c *Client) Close() {
 	c.closeHartBeat()
 	c.coordinator.Producers().Range(func(_, p any) bool {
 		producer := p.(*Producer)
@@ -522,7 +522,6 @@ func (c *Client) Close() error {
 		_ = c.coordinator.RemoveResponseById(res.correlationid)
 	}
 	c.getSocket().shutdown(nil)
-	return nil
 }
 
 func (c *Client) DeclarePublisher(streamName string, options *ProducerOptions) (*Producer, error) {

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -2,11 +2,12 @@ package stream
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 )
 
 type Coordinator struct {
@@ -86,7 +87,8 @@ func (coordinator *Coordinator) RemoveConsumerById(id interface{}, reason Event)
 	if err != nil {
 		return err
 	}
-	return consumer.close(reason)
+	consumer.close(reason)
+	return nil
 
 }
 func (coordinator *Coordinator) Consumers() *sync.Map {

--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -50,12 +50,7 @@ func NewEnvironment(options *EnvironmentOptions) (*Environment, error) {
 
 	client := newClient("go-stream-locator", nil,
 		options.TCPParameters, options.SaslConfiguration, options.RPCTimeout)
-	defer func(client *Client) {
-		err := client.Close()
-		if err != nil {
-			return
-		}
-	}(client)
+	defer client.Close()
 
 	// we put a limit to the heartbeat.
 	// it doesn't make sense to have a heartbeat less than 3 seconds
@@ -275,7 +270,7 @@ func (env *Environment) Close() error {
 	_ = env.producers.close()
 	_ = env.consumers.close()
 	if env.locator.client != nil {
-		_ = env.locator.client.Close()
+		env.locator.client.Close()
 	}
 	env.closed = true
 	return nil
@@ -581,10 +576,7 @@ func (cc *environmentCoordinator) newProducer(leader *Broker, tcpParameters *TCP
 		logs.LogDebug("connectionProperties host %s doesn't match with the advertised_host %s, advertised_port %s .. retry",
 			clientResult.connectionProperties.host,
 			leader.advHost, leader.advPort)
-		err := clientResult.Close()
-		if err != nil {
-			return nil, err
-		}
+		clientResult.Close()
 		clientResult = cc.newClientForProducer(clientProvidedName, leader, tcpParameters, saslConfiguration, rpcTimeout)
 		err = clientResult.connect()
 		if err != nil {

--- a/pkg/stream/environment_test.go
+++ b/pkg/stream/environment_test.go
@@ -2,9 +2,10 @@ package stream
 
 import (
 	"crypto/tls"
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"sync"
 	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -496,22 +497,22 @@ var _ = Describe("Environment test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		streamName := uuid.New().String()
 		// here we force the client closing
-		Expect(env.locator.client.Close()).NotTo(HaveOccurred())
+		env.locator.client.Close()
 		Expect(env.DeclareStream(streamName, nil)).NotTo(HaveOccurred())
 		Expect(env.locator.client.socket.isOpen()).To(BeTrue())
 		const consumerName = "my_consumer_1"
 		// here we force the client closing
-		Expect(env.locator.client.Close()).NotTo(HaveOccurred())
+		env.locator.client.Close()
 		Expect(env.StoreOffset(consumerName, streamName, 123)).NotTo(HaveOccurred())
 		Expect(env.locator.client.socket.isOpen()).To(BeTrue())
 		// here we force the client closing
-		Expect(env.locator.client.Close()).NotTo(HaveOccurred())
+		env.locator.client.Close()
 		off, err := env.QueryOffset(consumerName, streamName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(env.locator.client.socket.isOpen()).To(BeTrue())
 		Expect(off).To(Equal(int64(123)))
 		// here we force the client closing
-		Expect(env.locator.client.Close()).NotTo(HaveOccurred())
+		env.locator.client.Close()
 		Expect(env.DeleteStream(streamName)).NotTo(HaveOccurred())
 		Expect(env.locator.client.socket.isOpen()).To(BeTrue())
 		Expect(env.Close()).NotTo(HaveOccurred())

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -471,28 +471,57 @@ func (producer *Producer) internalBatchSend(messagesSequence []*messageSequence)
 	return producer.internalBatchSendProdId(messagesSequence, producer.GetID())
 }
 
-func (producer *Producer) simpleAggregation(messagesSequence []*messageSequence,
-	b *bufio.Writer) {
+func (producer *Producer) simpleAggregation(messagesSequence []*messageSequence, b *bufio.Writer) error {
 	for _, msg := range messagesSequence {
 		r := msg.messageBytes
-		writeBLong(b, msg.publishingId) // publishingId
-		writeBInt(b, len(r))            // len
-		b.Write(r)
+		// publishingId
+		if err := writeBLong(b, msg.publishingId); err != nil {
+			return err
+		}
+
+		// len
+		if err := writeBInt(b, len(r)); err != nil {
+			return err
+		}
+
+		if _, err := b.Write(r); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-func (producer *Producer) subEntryAggregation(aggregation subEntries, b *bufio.Writer, compression Compression) {
+func (producer *Producer) subEntryAggregation(aggregation subEntries, b *bufio.Writer, compression Compression) error {
 	/// 51 messages
 	// aggregation.items == (5 --> [10] messages) + (1 --> [1]message)
 	for _, entry := range aggregation.items {
-		writeBLong(b, entry.publishingId)
-		writeBByte(b, 0x80|
-			compression.value<<4) // 1=SubBatchEntryType:1,CompressionType:3,Reserved:4,
-		writeBShort(b, int16(len(entry.messages)))
-		writeBInt(b, entry.unCompressedSize)
-		writeBInt(b, entry.sizeInBytes)
-		b.Write(entry.dataInBytes)
+		if err := writeBLong(b, entry.publishingId); err != nil {
+			return fmt.Errorf("failed to write publishingId: %w", err)
+		}
+		// 1=SubBatchEntryType:1,CompressionType:3,Reserved:4,
+		if err := writeBByte(b, 0x80|compression.value<<4); err != nil {
+			return fmt.Errorf("failed to write type and compression byte: %w", err)
+		}
+
+		if err := writeBShort(b, int16(len(entry.messages))); err != nil {
+			return fmt.Errorf("failed to write message count: %w", err)
+		}
+
+		if err := writeBInt(b, entry.unCompressedSize); err != nil {
+			return fmt.Errorf("failed to write uncompressed size: %w", err)
+		}
+
+		if err := writeBInt(b, entry.sizeInBytes); err != nil {
+			return fmt.Errorf("failed to write size in bytes: %w", err)
+		}
+
+		if _, err := b.Write(entry.dataInBytes); err != nil {
+			return fmt.Errorf("failed to write data in bytes: %w", err)
+		}
 	}
+
+	return nil
 }
 
 func (producer *Producer) aggregateEntities(msgs []*messageSequence, size int, compression Compression) (subEntries, error) {
@@ -576,29 +605,44 @@ func (producer *Producer) internalBatchSendProdId(messagesSequence []*messageSeq
 	frameHeaderLength := initBufferPublishSize
 	length := frameHeaderLength + msgLen
 
-	writeBProtocolHeader(producer.options.client.socket.writer, length, commandPublish)
-	writeBByte(producer.options.client.socket.writer, producerID)
+	if err := writeBProtocolHeader(producer.options.client.socket.writer, length, commandPublish); err != nil {
+		return fmt.Errorf("failed to write protocol header: %w", err)
+	}
+
+	if err := writeBByte(producer.options.client.socket.writer, producerID); err != nil {
+		return fmt.Errorf("failed to write producer ID: %w", err)
+	}
+
 	numberOfMessages := len(messagesSequence)
 	numberOfMessages = numberOfMessages / producer.options.SubEntrySize
 	if len(messagesSequence)%producer.options.SubEntrySize != 0 {
 		numberOfMessages += 1
 	}
 
-	writeBInt(producer.options.client.socket.writer, numberOfMessages) //toExcluded - fromInclude
+	//toExcluded - fromInclude
+	if err := writeBInt(producer.options.client.socket.writer, numberOfMessages); err != nil {
+		return fmt.Errorf("failed to write number of messages: %w", err)
+	}
 
 	if producer.options.isSubEntriesBatching() {
-		producer.subEntryAggregation(aggregation, producer.options.client.socket.writer, producer.options.Compression)
+		err := producer.subEntryAggregation(aggregation, producer.options.client.socket.writer, producer.options.Compression)
+		if err != nil {
+			return fmt.Errorf("failed to write sub entry aggregation: %w", err)
+		}
 	}
 
 	if !producer.options.isSubEntriesBatching() {
-		producer.simpleAggregation(messagesSequence, producer.options.client.socket.writer)
+		err := producer.simpleAggregation(messagesSequence, producer.options.client.socket.writer)
+		if err != nil {
+			return fmt.Errorf("failed to write simple aggregation: %w", err)
+		}
 	}
 
-	err := producer.options.client.socket.writer.Flush() //writeAndFlush(b.Bytes())
+	err := producer.options.client.socket.writer.Flush()
 	if err != nil {
-		logs.LogError("Producer BatchSend error during flush: %s", err)
-		return err
+		return fmt.Errorf("producer BatchSend error during flush: %w", err)
 	}
+
 	return nil
 }
 
@@ -732,33 +776,55 @@ func (producer *Producer) sendWithFilter(messagesSequence []*messageSequence, pr
 	frameHeaderLength := initBufferPublishSize
 	var msgLen int
 	for _, msg := range messagesSequence {
-		msgLen += len(msg.messageBytes) + 8 + 4
+		msgLen += len(msg.messageBytes) + 8 + 4 // 8 for publishingId, 4 for message length
 		if msg.filterValue != "" {
-			msgLen += 2 + len(msg.filterValue)
+			msgLen += 2 + len(msg.filterValue) // 2 for string length, then string bytes
 		}
 	}
 	length := frameHeaderLength + msgLen
 
-	writeBProtocolHeaderVersion(producer.options.client.socket.writer, length, commandPublish, version2)
-	writeBByte(producer.options.client.socket.writer, producerID)
+	if err := writeBProtocolHeaderVersion(producer.options.client.socket.writer, length, commandPublish, version2); err != nil {
+		return fmt.Errorf("failed to write protocol header version: %w", err)
+	}
+
+	if err := writeBByte(producer.options.client.socket.writer, producerID); err != nil {
+		return fmt.Errorf("failed to write producer ID: %w", err)
+	}
+
 	numberOfMessages := len(messagesSequence)
-	writeBInt(producer.options.client.socket.writer, numberOfMessages)
+	if err := writeBInt(producer.options.client.socket.writer, numberOfMessages); err != nil {
+		return fmt.Errorf("failed to write number of messages: %w", err)
+	}
 
 	for _, msg := range messagesSequence {
-		writeBLong(producer.options.client.socket.writer, msg.publishingId)
-		if msg.filterValue != "" {
-			writeBString(producer.options.client.socket.writer, msg.filterValue)
-		} else {
-			writeBInt(producer.options.client.socket.writer, -1)
+		if err := writeBLong(producer.options.client.socket.writer, msg.publishingId); err != nil {
+			return fmt.Errorf("failed to write publishing ID for message: %w", err)
 		}
-		writeBInt(producer.options.client.socket.writer, len(msg.messageBytes)) // len
-		_, err := producer.options.client.socket.writer.Write(msg.messageBytes)
-		if err != nil {
-			return err
+
+		if msg.filterValue != "" {
+			if err := writeBString(producer.options.client.socket.writer, msg.filterValue); err != nil {
+				return fmt.Errorf("failed to write filter value for message: %w", err)
+			}
+		} else {
+			if err := writeBInt(producer.options.client.socket.writer, -1); err != nil {
+				return fmt.Errorf("failed to write -1 for filter value: %w", err)
+			}
+		}
+
+		if err := writeBInt(producer.options.client.socket.writer, len(msg.messageBytes)); err != nil {
+			return fmt.Errorf("failed to write message length: %w", err)
+		}
+
+		if _, err := producer.options.client.socket.writer.Write(msg.messageBytes); err != nil {
+			return fmt.Errorf("failed to write message bytes: %w", err)
 		}
 	}
 
-	return producer.options.client.socket.writer.Flush()
+	if err := producer.options.client.socket.writer.Flush(); err != nil {
+		return fmt.Errorf("failed to flush writer: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Client) deletePublisher(publisherId byte) error {

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -711,7 +711,7 @@ func (producer *Producer) close(reason Event) error {
 	_, _ = producer.options.client.coordinator.ExtractProducerById(producer.id)
 
 	if producer.options.client.coordinator.ProducersCount() == 0 {
-		_ = producer.options.client.Close()
+		producer.options.client.Close()
 	}
 
 	if producer.onClose != nil {

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -531,7 +531,10 @@ func (producer *Producer) aggregateEntities(msgs []*messageSequence, size int, c
 		}
 	}
 
-	compressByValue(compression.value).Compress(&subEntries)
+	err := compressByValue(compression.value).Compress(&subEntries)
+	if err != nil {
+		return subEntries, err
+	}
 
 	return subEntries, nil
 }

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -37,7 +37,7 @@ func (c *Client) handleResponse() {
 		frameLen, err := readUInt(buffer)
 		if err != nil {
 			logs.LogDebug("Read connection failed: %s", err)
-			_ = c.Close()
+			c.Close()
 			break
 		}
 

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -83,7 +83,6 @@ func (c *Client) handleResponse() {
 		case commandDeliver:
 			{
 				c.handleDeliver(buffer)
-
 			}
 		case commandQueryPublisherSequence:
 			{
@@ -296,6 +295,7 @@ func (c *Client) queryPublisherSequenceFrameHandler(readProtocol *ReaderProtocol
 	res.code <- Code{id: readProtocol.ResponseCode}
 	res.data <- sequence
 }
+
 func (c *Client) handleDeliver(r *bufio.Reader) {
 	subscriptionId := readByte(r)
 	consumer, err := c.coordinator.GetConsumerById(subscriptionId)
@@ -360,7 +360,7 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 	var chunk chunkInfo
 	chunk.numEntries = numEntries
 
-	/// headers ---> payload -> messages
+	// headers ---> payload -> messages
 
 	if consumer.options.CRCCheck {
 		checkSum := crc32.ChecksumIEEE(bytesBuffer)
@@ -400,9 +400,13 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 			dataSize, _ := readUInt(dataReader)
 			numRecords -= uint32(numRecordsInBatch)
 			compression := (entryType & 0x70) >> 4 //compression
-			uncompressedReader := compressByValue(compression).UnCompress(dataReader,
+			uncompressedReader, err := compressByValue(compression).UnCompress(dataReader,
 				dataSize,
 				uncompressedDataSize)
+			if err != nil {
+				// TODO: it should return error
+				logs.LogError("error during data uncompression %w", err)
+			}
 
 			for numRecordsInBatch != 0 {
 				batchConsumingMessages = c.decodeMessage(uncompressedReader,

--- a/pkg/stream/stream_suite_test.go
+++ b/pkg/stream/stream_suite_test.go
@@ -2,10 +2,11 @@ package stream_test
 
 import (
 	"fmt"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"net/http"
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const testVhost = "rabbitmq-streams-go-test"
@@ -48,7 +49,10 @@ func httpCall(method, url string) error {
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
+	err = resp.Body.Close()
+	if err != nil {
+		return err
+	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("http error (%d): %s", resp.StatusCode, resp.Status)

--- a/pkg/stream/super_stream_producer_test.go
+++ b/pkg/stream/super_stream_producer_test.go
@@ -48,7 +48,8 @@ var _ = Describe("Super Stream Producer", Label("super-stream-producer"), func()
 
 			msg := amqp.NewMessage(make([]byte, 0))
 			msg.ApplicationProperties = map[string]interface{}{"routingKey": key}
-			msg.MarshalBinary()
+			_, err := msg.MarshalBinary()
+			Expect(err).NotTo(HaveOccurred())
 			routing, err := routingMurmur.Route(msg, partitions)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routing).To(HaveLen(1))

--- a/pkg/stream/super_stream_producer_test.go
+++ b/pkg/stream/super_stream_producer_test.go
@@ -2,15 +2,16 @@ package stream
 
 import (
 	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/logs"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/test-helper"
-	"math/rand"
-	"sync"
-	"time"
+	test_helper "github.com/rabbitmq/rabbitmq-stream-go-client/pkg/test-helper"
 )
 
 type TestingRandomStrategy struct {
@@ -344,7 +345,7 @@ var _ = Describe("Super Stream Producer", Label("super-stream-producer"), func()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(route).To(Equal([]string{}))
 
-		Expect(env.locator.client.Close()).NotTo(HaveOccurred())
+		env.locator.client.Close()
 		Expect(env.DeleteSuperStream(superStream)).NotTo(HaveOccurred())
 		Expect(env.Close()).NotTo(HaveOccurred())
 	})
@@ -358,7 +359,7 @@ var _ = Describe("Super Stream Producer", Label("super-stream-producer"), func()
 		route, err := env.locator.client.queryRoute("not-found", "italy")
 		Expect(err).To(HaveOccurred())
 		Expect(route).To(BeNil())
-		Expect(env.locator.client.Close()).NotTo(HaveOccurred())
+		env.locator.client.Close()
 		Expect(env.Close()).NotTo(HaveOccurred())
 	})
 

--- a/pkg/stream/super_stream_test.go
+++ b/pkg/stream/super_stream_test.go
@@ -1,9 +1,10 @@
 package stream
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"time"
 )
 
 type testSuperStreamOption struct {
@@ -82,7 +83,7 @@ var _ = Describe("Super Stream Client", Label("super-stream"), func() {
 		err = testEnvironment.locator.client.DeclareSuperStream("valid name", newTestSuperStreamOption([]string{"valid "}, []string{""}, nil))
 		Expect(err).To(HaveOccurred())
 
-		Expect(testEnvironment.locator.client.Close()).NotTo(HaveOccurred())
+		testEnvironment.locator.client.Close()
 	})
 
 	It("Create Super stream two times and delete it with client", Label("super-stream"), func() {

--- a/pkg/system_integration/http.go
+++ b/pkg/system_integration/http.go
@@ -2,10 +2,11 @@ package system_integration
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type queue struct {
@@ -40,10 +41,11 @@ func httpGet(url, username, password string) (string, error) {
 		return "", err3
 	}
 
+	//nolint:errcheck
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 200 { // OK
-		bodyBytes, err2 := ioutil.ReadAll(resp.Body)
+		bodyBytes, err2 := io.ReadAll(resp.Body)
 		if err2 != nil {
 			return "", err2
 		}

--- a/pkg/test-helper/http_utils.go
+++ b/pkg/test-helper/http_utils.go
@@ -2,10 +2,11 @@ package test_helper
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type client_properties struct {
@@ -86,10 +87,11 @@ func baseCall(url, username, password string, method string) (string, error) {
 		return "", err3
 	}
 
+	//nolint:errcheck
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 200 { // OK
-		bodyBytes, err2 := ioutil.ReadAll(resp.Body)
+		bodyBytes, err2 := io.ReadAll(resp.Body)
 		if err2 != nil {
 			return "", err2
 		}


### PR DESCRIPTION
Implemented error checking for all previously unhandled errors in the client, specifically addressing socket write errors. This provides detailed error insights and prepares our codebase for [golangci-lint](https://github.com/golangci/golangci-lint) integration.
More PR is on the way to solve additional problems identified by golangci-lint.