### PR TITLE
Avoid to panic on close when the consumer internal queue is full

### DIFF
--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -342,8 +342,14 @@ func (consumer *Consumer) close(reason Event) {
 	}
 
 	if consumer.response.data != nil {
+		// drain the queue to avoid race condition
+		for len(consumer.chunkForConsumer) > 0 {
+			select {
+			case <-consumer.chunkForConsumer:
+			default:
+			}
+		}
 		close(consumer.chunkForConsumer)
-
 		close(consumer.response.data)
 		consumer.response.data = nil
 	}

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -404,13 +404,13 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 			}
 		}
 	}
-	// request a credit for the next chunk
-	c.credit(subscriptionId, 1)
 
 	// dispatch the messages with offset to the consumer
 	chunk.offsetMessages = batchConsumingMessages
 	if consumer.getStatus() == open {
 		consumer.chunkForConsumer <- chunk
+		// request a credit for the next chunk
+		c.credit(subscriptionId, 1)
 	} else {
 		logs.LogDebug("The consumer %s for the stream %s is closed during the chunk dispatching. "+
 			"Messages won't dispatched", consumer.GetName(), consumer.GetStreamName())


### PR DESCRIPTION
Tested and fixed the issue described in #393.
Added a drain with @Gsantomaggio before the close to avoid race condition with the client with pending messages.

More details are also in this PR #411.