### PR TITLE
Add manual credit flow

### DIFF
--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -693,7 +694,9 @@ func (c *Client) BrokerLeader(stream string) (*Broker, error) {
 	streamMetadata.Leader.advHost = streamMetadata.Leader.Host
 
 	// see: https://github.com/rabbitmq/rabbitmq-stream-go-client/pull/317
-	_, err := net.LookupIP(streamMetadata.Leader.Host)
+	ctx, cancel := context.WithTimeout(context.Background(), c.socketCallTimeout)
+	defer cancel()
+	_, err := net.DefaultResolver.LookupIPAddr(ctx, streamMetadata.Leader.Host)
 	if err != nil {
 		var dnsError *net.DNSError
 		if errors.As(err, &dnsError) {

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -410,7 +410,9 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 	if consumer.getStatus() == open {
 		consumer.chunkForConsumer <- chunk
 		// request a credit for the next chunk
-		c.credit(subscriptionId, 1)
+		if consumer.options.CreditStrategy == AutomaticCreditStrategy {
+			c.credit(subscriptionId, 1)
+		}
 	} else {
 		logs.LogDebug("The consumer %s for the stream %s is closed during the chunk dispatching. "+
 			"Messages won't dispatched", consumer.GetName(), consumer.GetStreamName())


### PR DESCRIPTION
Add a consumer option to set the credit flow strategy. By default, it uses automatic credit
strategy. This strategy sends 1 credit after dispatching a chunk to the consumer. In the
manual credit strategy, the user is responsible for sending credits to the server.
