### PR TITLE
Fix race condition on producer close handler when reconnecting via reliable producer

### DIFF
--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -218,6 +218,8 @@ func (producer *Producer) NotifyPublishConfirmation() ChannelPublishConfirm {
 
 // NotifyClose returns a channel that receives the close event of the producer.
 func (producer *Producer) NotifyClose() ChannelClose {
+	producer.mutex.Lock()
+	defer producer.mutex.Unlock()
 	ch := make(chan Event, 1)
 	producer.closeHandler = ch
 	return ch
@@ -675,6 +677,10 @@ func (producer *Producer) close(reason Event) error {
 
 	reason.StreamName = producer.GetStreamName()
 	reason.Name = producer.GetName()
+
+	producer.mutex.Lock()
+	defer producer.mutex.Unlock()
+
 	if producer.closeHandler != nil {
 		producer.closeHandler <- reason
 		close(producer.closeHandler)


### PR DESCRIPTION
This is a potential simple fix for https://github.com/rabbitmq/rabbitmq-stream-go-client/issues/430 which has a detailed explanation of the issue and how to reproduce it.

The TL;DR version is that the reliable producer tries to get a new standard producer instance during retrying the connection which can result in a race condition during the client closing the producer and the producer setting a new channel for the handler during the `NotifyClose` call. Having a mutex over the close handler access prevents this.

I've was able to rerun the integration test shared on the issue and I don't experience the problem anymore.