### PR TITLE
Revert #431

### DIFF
--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -218,8 +218,6 @@ func (producer *Producer) NotifyPublishConfirmation() ChannelPublishConfirm {
 
 // NotifyClose returns a channel that receives the close event of the producer.
 func (producer *Producer) NotifyClose() ChannelClose {
-	// producer.mutex.Lock()
-	//defer producer.mutex.Unlock()
 	ch := make(chan Event, 1)
 	producer.closeHandler = ch
 	return ch
@@ -677,9 +675,6 @@ func (producer *Producer) close(reason Event) error {
 
 	reason.StreamName = producer.GetStreamName()
 	reason.Name = producer.GetName()
-
-	// producer.mutex.Lock()
-	//defer producer.mutex.Unlock()
 
 	if producer.closeHandler != nil {
 		producer.closeHandler <- reason


### PR DESCRIPTION
The tests don't pass with #431

@Kem-Gov  @hiimjako I had to revert the FIX. We merged it too quickly.  The tests don't pass with that fix

```
docker run -it --rm --name rabbitmq -p 5552:5552 -p 5672:5672 -p 15672:15672 \
    -e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-rabbitmq_stream advertised_host localhost' \
    rabbitmq:4-management
```
then
```
docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stream_management rabbitmq_amqp1_0
```

then `make test` 
