### PR TITLE
Move automatic credit strategy in the handler thread

### DIFF
--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -497,7 +497,8 @@ var _ = Describe("Streaming Consumers", func() {
 
 		// waiting the internal queue to fulfill
 		time.Sleep(time.Second)
-		Expect(len(consumer.chunkForConsumer)).To(Equal(credits))
+		// - 1 because the first message was consumed by the handler
+		Expect(len(consumer.chunkForConsumer)).To(Equal(credits - 1))
 
 		Expect(consumer.Close()).NotTo(HaveOccurred())
 	})

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -198,8 +198,9 @@ func (coordinator *Coordinator) NewConsumer(
 		lastStoredOffset:     -1, // because 0 is a valid value for the offset
 		isPromotedAsActive:   true,
 		lastAutoCommitStored: time.Now(),
-		chunkForConsumer:     make(chan chunkInfo, parameters.initialCredits),
-		onClose:              cleanUp,
+		// The +5 provides a small buffer to prevent the consumer loop from blocking.
+		chunkForConsumer: make(chan chunkInfo, parameters.initialCredits+5),
+		onClose:          cleanUp,
 	}
 
 	coordinator.consumers.Store(lastId, item)

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -409,10 +409,6 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 	chunk.offsetMessages = batchConsumingMessages
 	if consumer.getStatus() == open {
 		consumer.chunkForConsumer <- chunk
-		// request a credit for the next chunk
-		if consumer.options.CreditStrategy == AutomaticCreditStrategy {
-			c.credit(subscriptionId, 1)
-		}
 	} else {
 		logs.LogDebug("The consumer %s for the stream %s is closed during the chunk dispatching. "+
 			"Messages won't dispatched", consumer.GetName(), consumer.GetStreamName())


### PR DESCRIPTION
This PR moves the `AutomaticCreditStrategy` into the handler thread. It now requests credits after half of a chunk has been processed, which aligns its behavior with the Java client.
This change prevents the main socket loop from blocking and ensures that heartbeats are handled correctly.

Fixes #439 

Performance remains quite the same. The following command was used for testing, with 15 samples recorded for each run:
`go run ./perftest.go --publishers 1 --consumers 1 --streams test-stream --max-length-bytes 2GB --initial-credits <num>`

- Default credits (10):
  - main
```sh
2026/09/25 18:55:38 [info] - Silent (1.6.0) Simulation, url: [rabbitmq-stream://guest:guest@localhost:5552/%2f] publishers: 1 consumers: 1 streams: [my_stream_curr] 
2025/09/25 18:55:38 [info] - Declaring streams: [my_stream_curr]
2025/09/25 18:55:38 [info] - stream my_stream_curr, meta data: leader localhost:5552, followers  
2025/09/25 18:55:38 [info] - End Init streams :[my_stream_curr]
2025/09/25 18:55:38 [info] - Starting 1 consumers...
2025/09/25 18:55:38 [info] - Starting consumer number: my_stream_curr-0, form first
2025/09/25 18:55:38 [info] - Starting 1 publishers...
2025/09/25 18:55:38 [info] - Starting publisher number: 1
2025/09/25 18:55:39 [info] - Published 24,400.0 msg/s | Confirmed 14,200.0 msg/s |  Consumed  4,064.0 msg/s |  Full | Body sz: 8 | latency: 15 ms
2025/09/25 18:55:40 [info] - Published 18,200.0 msg/s | Confirmed 13,128.0 msg/s |  Consumed  4,080.0 msg/s |  Full | Body sz: 8 | latency: 561 ms
2025/09/25 18:55:41 [info] - Published 15,600.0 msg/s | Confirmed 12,242.7 msg/s |  Consumed  6,150.0 msg/s |  Full | Body sz: 8 | latency: 1,696 ms
2025/09/25 18:55:42 [info] - Published 13,750.0 msg/s | Confirmed 11,200.0 msg/s |  Consumed  5,572.5 msg/s |  Full | Body sz: 8 | latency: 1,907 ms
2025/09/25 18:55:43 [info] - Published 13,040.0 msg/s | Confirmed 11,000.0 msg/s |  Consumed  5,836.8 msg/s |  Full | Body sz: 8 | latency: 2,262 ms
2025/09/25 18:55:44 [info] - Published 12,566.7 msg/s | Confirmed 10,866.7 msg/s |  Consumed  6,164.0 msg/s |  Full | Body sz: 8 | latency: 2,625 ms
2025/09/25 18:55:45 [info] - Published 12,228.6 msg/s | Confirmed 10,771.4 msg/s |  Consumed  5,890.0 msg/s |  Full | Body sz: 8 | latency: 2,796 ms
2025/09/25 18:55:46 [info] - Published 11,975.0 msg/s | Confirmed 10,700.0 msg/s |  Consumed  5,946.0 msg/s |  Full | Body sz: 8 | latency: 3,048 ms
2025/09/25 18:55:47 [info] - Published 11,554.3 msg/s | Confirmed 10,421.1 msg/s |  Consumed  5,975.3 msg/s |  Full | Body sz: 8 | latency: 3,264 ms
2025/09/25 18:55:48 [info] - Published 11,420.0 msg/s | Confirmed 10,400.0 msg/s |  Consumed  5,900.0 msg/s |  Full | Body sz: 8 | latency: 3,460 ms
2025/09/25 18:55:49 [info] - Published 11,309.1 msg/s | Confirmed 10,384.5 msg/s |  Consumed  5,721.5 msg/s |  Full | Body sz: 8 | latency: 3,621 ms
2025/09/25 18:55:50 [info] - Published 11,216.7 msg/s | Confirmed 10,366.7 msg/s |  Consumed  5,663.9 msg/s |  Full | Body sz: 8 | latency: 3,836 ms
2025/09/25 18:55:51 [info] - Published 11,138.5 msg/s | Confirmed 10,353.8 msg/s |  Consumed  5,665.8 msg/s |  Full | Body sz: 8 | latency: 4,090 ms
2025/09/25 18:55:52 [info] - Published 11,071.4 msg/s | Confirmed 10,342.9 msg/s |  Consumed  5,597.7 msg/s |  Full | Body sz: 8 | latency: 4,292 ms
2025/09/25 18:55:53 [info] - Published 10,880.0 msg/s | Confirmed 10,200.0 msg/s |  Consumed  5,573.3 msg/s |  Full | Body sz: 8 | latency: 4,509 ms
2025/09/25 18:55:54 [info] - Published 10,837.5 msg/s | Confirmed 10,200.0 msg/s |  Consumed  5,535.5 msg/s |  Full | Body sz: 8 | latency: 4,721 ms
2025/09/25 18:55:55 [info] - Published 10,800.0 msg/s | Confirmed 10,200.0 msg/s |  Consumed  5,448.5 msg/s |  Full | Body sz: 8 | latency: 4,910 ms

```
  - PR
```sh
2025/09/25 18:58:44 [info] - Silent (1.6.0) Simulation, url: [rabbitmq-stream://guest:guest@localhost:5552/%2f] publishers: 1 consumers: 1 streams: [my_stream_new] 
2025/09/25 18:58:44 [info] - Declaring streams: [my_stream_new]
2025/09/25 18:58:44 [info] - stream my_stream_new, meta data: leader localhost:5552, followers  
2025/09/25 18:58:44 [info] - End Init streams :[my_stream_new]
2025/09/25 18:58:44 [info] - Starting 1 consumers...
2025/09/25 18:58:44 [info] - Starting consumer number: my_stream_new-0, form first
2025/09/25 18:58:44 [info] - Starting 1 publishers...
2025/09/25 18:58:44 [info] - Starting publisher number: 1
2025/09/25 18:58:45 [info] - Published 39,000.0 msg/s | Confirmed 28,800.0 msg/s |  Consumed  9,514.0 msg/s |  Full | Body sz: 8 | latency: 173 ms
2025/09/25 18:58:46 [info] - Published 24,600.0 msg/s | Confirmed 19,500.0 msg/s |  Consumed  8,417.5 msg/s |  Full | Body sz: 8 | latency: 701 ms
2025/09/25 18:58:47 [info] - Published 19,400.0 msg/s | Confirmed 16,056.0 msg/s |  Consumed  6,573.3 msg/s |  Full | Body sz: 8 | latency: 928 ms
2025/09/25 18:58:48 [info] - Published 17,050.0 msg/s | Confirmed 14,500.0 msg/s |  Consumed  6,300.0 msg/s |  Full | Body sz: 8 | latency: 1,515 ms
2025/09/25 18:58:49 [info] - Published 15,157.0 msg/s | Confirmed 13,117.4 msg/s |  Consumed  5,758.8 msg/s |  Full | Body sz: 8 | latency: 1,892 ms
2025/09/25 18:58:50 [info] - Published 14,200.0 msg/s | Confirmed 12,533.2 msg/s |  Consumed  5,942.7 msg/s |  Full | Body sz: 8 | latency: 2,532 ms
2025/09/25 18:58:51 [info] - Published 13,514.3 msg/s | Confirmed 12,057.1 msg/s |  Consumed  5,893.7 msg/s |  Full | Body sz: 8 | latency: 2,956 ms
2025/09/25 18:58:52 [info] - Published 13,050.0 msg/s | Confirmed 11,788.0 msg/s |  Consumed  5,625.0 msg/s |  Full | Body sz: 8 | latency: 3,219 ms
2025/09/25 18:58:53 [info] - Published 12,665.3 msg/s | Confirmed 11,547.2 msg/s |  Consumed  5,545.2 msg/s |  Full | Body sz: 8 | latency: 3,550 ms
2025/09/25 18:58:54 [info] - Published 12,180.0 msg/s | Confirmed 11,160.0 msg/s |  Consumed  5,556.8 msg/s |  Full | Body sz: 8 | latency: 3,905 ms
2025/09/25 18:58:55 [info] - Published 11,927.3 msg/s | Confirmed 11,011.6 msg/s |  Consumed  5,542.5 msg/s |  Full | Body sz: 8 | latency: 4,212 ms
2025/09/25 18:58:56 [info] - Published 11,700.0 msg/s | Confirmed 10,865.3 msg/s |  Consumed  5,550.0 msg/s |  Full | Body sz: 8 | latency: 4,513 ms
2025/09/25 18:58:57 [info] - Published 11,507.7 msg/s | Confirmed 10,724.9 msg/s |  Consumed  5,481.2 msg/s |  Full | Body sz: 8 | latency: 4,759 ms
2025/09/25 18:58:58 [info] - Published 11,414.3 msg/s | Confirmed 10,695.7 msg/s |  Consumed  5,718.3 msg/s |  Full | Body sz: 8 | latency: 5,188 ms
2025/09/25 18:58:59 [info] - Published 11,160.0 msg/s | Confirmed 10,491.2 msg/s |  Consumed  5,794.1 msg/s |  Full | Body sz: 8 | latency: 5,473 ms
2025/09/25 18:59:00 [info] - Published 11,012.5 msg/s | Confirmed 10,382.0 msg/s |  Consumed  5,623.0 msg/s |  Full | Body sz: 8 | latency: 5,599 ms
2025/09/25 18:59:01 [info] - Published 10,987.6 msg/s | Confirmed 10,387.6 msg/s |  Consumed  5,682.0 msg/s |  Full | Body sz: 8 | latency: 5,869 ms
```
- One credit (1):
  - main
```sh
2025/09/25 18:56:19 [info] - Silent (1.6.0) Simulation, url: [rabbitmq-stream://guest:guest@localhost:5552/%2f] publishers: 1 consumers: 1 streams: [my_stream_curr_1_cred] 
2025/09/25 18:56:19 [info] - Declaring streams: [my_stream_curr_1_cred]
2025/09/25 18:56:19 [info] - stream my_stream_curr_1_cred, meta data: leader localhost:5552, followers  
2025/09/25 18:56:19 [info] - End Init streams :[my_stream_curr_1_cred]
2025/09/25 18:56:19 [info] - Starting 1 consumers...
2025/09/25 18:56:19 [info] - Starting consumer number: my_stream_curr_1_cred-0, form first
2025/09/25 18:56:19 [info] - Starting 1 publishers...
2025/09/25 18:56:19 [info] - Starting publisher number: 1
2025/09/25 18:56:20 [info] - Published 26,200.0 msg/s | Confirmed 16,168.0 msg/s |  Consumed 10,024.0 msg/s |  Full | Body sz: 8 | latency: 310 ms
2025/09/25 18:56:21 [info] - Published 18,400.0 msg/s | Confirmed 13,380.0 msg/s |  Consumed  8,084.0 msg/s |  Full | Body sz: 8 | latency: 754 ms
2025/09/25 18:56:22 [info] - Published 15,466.7 msg/s | Confirmed 12,107.3 msg/s |  Consumed 15,466.7 msg/s |  Full | Body sz: 8 | latency: 904 ms
2025/09/25 18:56:23 [info] - Published 14,796.3 msg/s | Confirmed 12,288.9 msg/s |  Consumed 13,596.6 msg/s |  Full | Body sz: 8 | latency: 788 ms
2025/09/25 18:56:24 [info] - Published 13,400.0 msg/s | Confirmed 11,387.2 msg/s |  Consumed 13,400.0 msg/s |  Full | Body sz: 8 | latency: 693 ms
2025/09/25 18:56:25 [info] - Published 12,933.3 msg/s | Confirmed 11,242.3 msg/s |  Consumed 12,933.3 msg/s |  Full | Body sz: 8 | latency: 608 ms
2025/09/25 18:56:26 [info] - Published 12,542.9 msg/s | Confirmed 11,099.4 msg/s |  Consumed 12,542.9 msg/s |  Full | Body sz: 8 | latency: 548 ms
2025/09/25 18:56:27 [info] - Published 12,175.0 msg/s | Confirmed 10,912.9 msg/s |  Consumed 11,789.9 msg/s |  Full | Body sz: 8 | latency: 524 ms
2025/09/25 18:56:28 [info] - Published 11,822.2 msg/s | Confirmed 10,707.6 msg/s |  Consumed 11,656.9 msg/s |  Full | Body sz: 8 | latency: 498 ms
2025/09/25 18:56:29 [info] - Published 11,460.0 msg/s | Confirmed 10,440.0 msg/s |  Consumed 11,256.8 msg/s |  Full | Body sz: 8 | latency: 472 ms
2025/09/25 18:56:30 [info] - Published 11,236.4 msg/s | Confirmed 10,326.5 msg/s |  Consumed 11,236.4 msg/s |  Full | Body sz: 8 | latency: 441 ms
2025/09/25 18:56:31 [info] - Published 11,166.7 msg/s | Confirmed 10,332.0 msg/s |  Consumed 11,076.0 msg/s |  Full | Body sz: 8 | latency: 415 ms
2025/09/25 18:56:32 [info] - Published 11,000.0 msg/s | Confirmed 10,224.0 msg/s |  Consumed 10,951.4 msg/s |  Full | Body sz: 8 | latency: 408 ms
2025/09/25 18:56:33 [info] - Published 10,957.1 msg/s | Confirmed 10,232.6 msg/s |  Consumed 10,892.6 msg/s |  Full | Body sz: 8 | latency: 387 ms
2025/09/25 18:56:34 [info] - Published 10,786.7 msg/s | Confirmed 10,106.7 msg/s |  Consumed 10,704.5 msg/s |  Full | Body sz: 8 | latency: 374 ms
2025/09/25 18:56:35 [info] - Published 10,662.5 msg/s | Confirmed 10,035.5 msg/s |  Consumed 10,537.5 msg/s |  Full | Body sz: 8 | latency: 365 ms
2025/09/25 18:56:36 [info] - Published 10,635.3 msg/s | Confirmed 10,043.4 msg/s |  Consumed 10,562.8 msg/s |  Full | Body sz: 8 | latency: 353 ms
```
  - PR
```sh
2025/09/25 18:57:57 [info] - Silent (1.6.0) Simulation, url: [rabbitmq-stream://guest:guest@localhost:5552/%2f] publishers: 1 consumers: 1 streams: [my_stream_new_1_cred] 
2025/09/25 18:57:57 [info] - Declaring streams: [my_stream_new_1_cred]
2025/09/25 18:57:57 [info] - stream my_stream_new_1_cred, meta data: leader localhost:5552, followers  
2025/09/25 18:57:57 [info] - End Init streams :[my_stream_new_1_cred]
2025/09/25 18:57:57 [info] - Starting 1 consumers...
2025/09/25 18:57:58 [info] - Starting consumer number: my_stream_new_1_cred-0, form first
2025/09/25 18:57:58 [info] - Starting 1 publishers...
2025/09/25 18:57:58 [info] - Starting publisher number: 1
2025/09/25 18:57:59 [info] - Published 23,800.0 msg/s | Confirmed 13,738.0 msg/s |  Consumed  9,642.0 msg/s |  Full | Body sz: 8 | latency: 163 ms
2025/09/25 18:58:00 [info] - Published 17,400.0 msg/s | Confirmed 12,364.0 msg/s |  Consumed 10,506.0 msg/s |  Full | Body sz: 8 | latency: 888 ms
2025/09/25 18:58:01 [info] - Published 14,733.3 msg/s | Confirmed 11,394.7 msg/s |  Consumed 13,618.3 msg/s |  Full | Body sz: 8 | latency: 901 ms
2025/09/25 18:58:02 [info] - Published 13,400.0 msg/s | Confirmed 10,856.0 msg/s |  Consumed 12,500.0 msg/s |  Full | Body sz: 8 | latency: 799 ms
2025/09/25 18:58:03 [info] - Published 12,320.0 msg/s | Confirmed 10,302.4 msg/s |  Consumed 12,320.0 msg/s |  Full | Body sz: 8 | latency: 686 ms
2025/09/25 18:58:04 [info] - Published 12,233.3 msg/s | Confirmed 10,561.3 msg/s |  Consumed 11,528.0 msg/s |  Full | Body sz: 8 | latency: 639 ms
2025/09/25 18:58:05 [info] - Published 11,857.1 msg/s | Confirmed 10,408.0 msg/s |  Consumed 11,613.7 msg/s |  Full | Body sz: 8 | latency: 612 ms
2025/09/25 18:58:06 [info] - Published 11,725.0 msg/s | Confirmed 10,456.2 msg/s |  Consumed 11,464.0 msg/s |  Full | Body sz: 8 | latency: 558 ms
2025/09/25 18:58:07 [info] - Published 11,577.8 msg/s | Confirmed 10,449.4 msg/s |  Consumed 11,577.8 msg/s |  Full | Body sz: 8 | latency: 515 ms
2025/09/25 18:58:08 [info] - Published 11,200.0 msg/s | Confirmed 10,180.0 msg/s |  Consumed 11,200.0 msg/s |  Full | Body sz: 8 | latency: 484 ms
2025/09/25 18:58:09 [info] - Published 10,981.8 msg/s | Confirmed 10,069.1 msg/s |  Consumed 10,981.8 msg/s |  Full | Body sz: 8 | latency: 456 ms
2025/09/25 18:58:10 [info] - Published 10,916.7 msg/s | Confirmed 10,077.3 msg/s |  Consumed 10,816.0 msg/s |  Full | Body sz: 8 | latency: 430 ms
2025/09/25 18:58:11 [info] - Published 10,753.8 msg/s | Confirmed  9,984.0 msg/s |  Consumed 10,584.0 msg/s |  Full | Body sz: 8 | latency: 410 ms
2025/09/25 18:58:12 [info] - Published 10,756.4 msg/s | Confirmed 10,039.9 msg/s |  Consumed 10,756.4 msg/s |  Full | Body sz: 8 | latency: 385 ms
2025/09/25 18:58:13 [info] - Published 10,559.3 msg/s | Confirmed  9,890.5 msg/s |  Consumed 10,559.3 msg/s |  Full | Body sz: 8 | latency: 369 ms
2025/09/25 18:58:14 [info] - Published 10,637.5 msg/s | Confirmed 10,012.0 msg/s |  Consumed 10,637.5 msg/s |  Full | Body sz: 8 | latency: 365 ms
2025/09/25 18:58:15 [info] - Published 10,658.8 msg/s | Confirmed 10,064.5 msg/s |  Consumed 10,658.8 msg/s |  Full | Body sz: 8 | latency: 350 ms
```
- Hundred credits (100):
  - main
```sh
2025/09/25 19:01:13 [info] - Silent (1.6.0) Simulation, url: [rabbitmq-stream://guest:guest@localhost:5552/%2f] publishers: 1 consumers: 1 streams: [my_stream_curr_100_cred] 
2025/09/25 19:01:13 [info] - Declaring streams: [my_stream_curr_100_cred]
2025/09/25 19:01:13 [info] - stream my_stream_curr_100_cred, meta data: leader localhost:5552, followers  
2025/09/25 19:01:13 [info] - End Init streams :[my_stream_curr_100_cred]
2025/09/25 19:01:13 [info] - Starting 1 consumers...
2025/09/25 19:01:13 [info] - Starting consumer number: my_stream_curr_100_cred-0, form first
2025/09/25 19:01:13 [info] - Starting 1 publishers...
2025/09/25 19:01:13 [info] - Starting publisher number: 1
2025/09/25 19:01:14 [info] - Published 64,400.0 msg/s | Confirmed 54,367.0 msg/s |  Consumed  6,706.0 msg/s |  Full | Body sz: 8 | latency: 205 ms
2025/09/25 19:01:15 [info] - Published 37,600.0 msg/s | Confirmed 32,556.0 msg/s |  Consumed  5,662.0 msg/s |  Full | Body sz: 8 | latency: 683 ms
2025/09/25 19:01:16 [info] - Published 28,066.7 msg/s | Confirmed 24,712.0 msg/s |  Consumed  5,466.7 msg/s |  Full | Body sz: 8 | latency: 1,231 ms
2025/09/25 19:01:17 [info] - Published 23,150.0 msg/s | Confirmed 20,611.0 msg/s |  Consumed  5,682.8 msg/s |  Full | Body sz: 8 | latency: 1,911 ms
2025/09/25 19:01:18 [info] - Published 20,480.0 msg/s | Confirmed 18,440.0 msg/s |  Consumed  4,996.8 msg/s |  Full | Body sz: 8 | latency: 2,136 ms
2025/09/25 19:01:19 [info] - Published 18,533.3 msg/s | Confirmed 16,837.3 msg/s |  Consumed  5,233.3 msg/s |  Full | Body sz: 8 | latency: 2,799 ms
2025/09/25 19:01:20 [info] - Published 17,342.9 msg/s | Confirmed 15,885.7 msg/s |  Consumed  5,150.9 msg/s |  Full | Body sz: 8 | latency: 3,279 ms
2025/09/25 19:01:21 [info] - Published 16,325.0 msg/s | Confirmed 15,064.0 msg/s |  Consumed  5,300.0 msg/s |  Full | Body sz: 8 | latency: 3,927 ms
2025/09/25 19:01:22 [info] - Published 15,377.8 msg/s | Confirmed 14,247.1 msg/s |  Consumed  5,358.2 msg/s |  Full | Body sz: 8 | latency: 4,477 ms
2025/09/25 19:01:23 [info] - Published 14,820.0 msg/s | Confirmed 13,813.6 msg/s |  Consumed  5,027.1 msg/s |  Full | Body sz: 8 | latency: 4,683 ms
2025/09/25 19:01:24 [info] - Published 14,327.3 msg/s | Confirmed 13,415.3 msg/s |  Consumed  4,942.5 msg/s |  Full | Body sz: 8 | latency: 5,113 ms
2025/09/25 19:01:25 [info] - Published 13,933.3 msg/s | Confirmed 13,092.7 msg/s |  Consumed  5,383.3 msg/s |  Full | Body sz: 8 | latency: 6,048 ms
2025/09/25 19:01:26 [info] - Published 13,569.2 msg/s | Confirmed 12,793.2 msg/s |  Consumed  5,456.0 msg/s |  Full | Body sz: 8 | latency: 6,521 ms
2025/09/25 19:01:27 [info] - Published 13,157.1 msg/s | Confirmed 12,430.3 msg/s |  Consumed  5,658.9 msg/s |  Full | Body sz: 8 | latency: 7,040 ms
2025/09/25 19:01:28 [info] - Published 12,933.3 msg/s | Confirmed 12,262.4 msg/s |  Consumed  5,792.0 msg/s |  Full | Body sz: 8 | latency: 7,454 ms
2025/09/25 19:01:29 [info] - Published 12,712.5 msg/s | Confirmed 12,082.0 msg/s |  Consumed  5,912.5 msg/s |  Full | Body sz: 8 | latency: 7,800 ms
2025/09/25 19:01:30 [info] - Published 12,541.2 msg/s | Confirmed 11,947.8 msg/s |  Consumed  5,882.4 msg/s |  Full | Body sz: 8 | latency: 8,035 ms
```
  - PR
```sh
2025/09/25 19:00:26 [info] - Silent (1.6.0) Simulation, url: [rabbitmq-stream://guest:guest@localhost:5552/%2f] publishers: 1 consumers: 1 streams: [my_stream_new_100_cred] 
2025/09/25 19:00:26 [info] - Declaring streams: [my_stream_new_100_cred]
2025/09/25 19:00:26 [info] - stream my_stream_new_100_cred, meta data: leader localhost:5552, followers  
2025/09/25 19:00:26 [info] - End Init streams :[my_stream_new_100_cred]
2025/09/25 19:00:26 [info] - Starting 1 consumers...
2025/09/25 19:00:27 [info] - Starting consumer number: my_stream_new_100_cred-0, form first
2025/09/25 19:00:27 [info] - Starting 1 publishers...
2025/09/25 19:00:27 [info] - Starting publisher number: 1
2025/09/25 19:00:28 [info] - Published 30,600.0 msg/s | Confirmed 20,533.0 msg/s |  Consumed  7,696.0 msg/s |  Full | Body sz: 8 | latency: 332 ms
2025/09/25 19:00:29 [info] - Published 20,700.0 msg/s | Confirmed 15,684.0 msg/s |  Consumed  7,259.5 msg/s |  Full | Body sz: 8 | latency: 877 ms
2025/09/25 19:00:30 [info] - Published 16,800.0 msg/s | Confirmed 13,447.7 msg/s |  Consumed  6,161.7 msg/s |  Full | Body sz: 8 | latency: 1,221 ms
2025/09/25 19:00:31 [info] - Published 14,696.3 msg/s | Confirmed 12,175.0 msg/s |  Consumed  6,180.0 msg/s |  Full | Body sz: 8 | latency: 1,790 ms
2025/09/25 19:00:32 [info] - Published 13,320.0 msg/s | Confirmed 11,302.4 msg/s |  Consumed  6,273.6 msg/s |  Full | Body sz: 8 | latency: 2,228 ms
2025/09/25 19:00:33 [info] - Published 12,600.0 msg/s | Confirmed 10,900.0 msg/s |  Consumed  6,932.0 msg/s |  Full | Body sz: 8 | latency: 2,679 ms
2025/09/25 19:00:34 [info] - Published 12,057.1 msg/s | Confirmed 10,616.0 msg/s |  Consumed  7,105.1 msg/s |  Full | Body sz: 8 | latency: 2,891 ms
2025/09/25 19:00:35 [info] - Published 11,575.0 msg/s | Confirmed 10,300.0 msg/s |  Consumed  7,314.0 msg/s |  Full | Body sz: 8 | latency: 3,071 ms
2025/09/25 19:00:36 [info] - Published 11,355.6 msg/s | Confirmed 10,240.9 msg/s |  Consumed  7,323.6 msg/s |  Full | Body sz: 8 | latency: 3,184 ms
2025/09/25 19:00:37 [info] - Published 10,940.0 msg/s | Confirmed  9,938.3 msg/s |  Consumed  7,560.0 msg/s |  Full | Body sz: 8 | latency: 3,288 ms
2025/09/25 19:00:38 [info] - Published 10,763.6 msg/s | Confirmed  9,848.0 msg/s |  Consumed  7,672.7 msg/s |  Full | Body sz: 8 | latency: 3,363 ms
2025/09/25 19:00:39 [info] - Published 10,566.7 msg/s | Confirmed  9,716.7 msg/s |  Consumed  7,738.0 msg/s |  Full | Body sz: 8 | latency: 3,417 ms
2025/09/25 19:00:40 [info] - Published 10,446.2 msg/s | Confirmed  9,674.5 msg/s |  Consumed  7,808.8 msg/s |  Full | Body sz: 8 | latency: 3,468 ms
2025/09/25 19:00:41 [info] - Published 10,371.4 msg/s | Confirmed  9,642.9 msg/s |  Consumed  7,837.7 msg/s |  Full | Body sz: 8 | latency: 3,516 ms
2025/09/25 19:00:42 [info] - Published 10,133.3 msg/s | Confirmed  9,546.7 msg/s |  Consumed  7,773.3 msg/s |  Full | Body sz: 8 | latency: 3,556 ms
2025/09/25 19:00:43 [info] - Published 10,075.0 msg/s | Confirmed  9,444.5 msg/s |  Consumed  7,860.5 msg/s |  Full | Body sz: 8 | latency: 3,598 ms
2025/09/25 19:00:44 [info] - Published 10,011.8 msg/s | Confirmed  9,411.8 msg/s |  Consumed  7,971.3 msg/s |  Full | Body sz: 8 | latency: 3,635 ms
```

