### PR TITLE
Skip DNS lookup when `AddressResolver` is configured

### DIFF
--- a/pkg/stream/environment.go
+++ b/pkg/stream/environment.go
@@ -664,7 +664,7 @@ func (ps *producersEnvironment) newProducer(clientLocator *Client, streamName st
 	options *ProducerOptions, resolver *AddressResolver, rpcTimeOut time.Duration) (*Producer, error) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
-	leader, err := clientLocator.BrokerLeader(streamName)
+	leader, err := clientLocator.BrokerLeaderWithResolver(streamName, resolver)
 	if err != nil {
 		return nil, err
 	}
@@ -728,7 +728,7 @@ func (ps *consumersEnvironment) NewSubscriber(clientLocator *Client, streamName 
 	consumerOptions *ConsumerOptions, resolver *AddressResolver, rpcTimeout time.Duration) (*Consumer, error) {
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
-	consumerBroker, err := clientLocator.BrokerForConsumer(streamName)
+	consumerBroker, err := clientLocator.BrokerForConsumerWithResolver(streamName, resolver)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When an `AddressResolver` is configured, the client still attempts DNS lookups for advertised broker hostnames from metadata responses. This causes 10-second timeouts per connection before falling back to the resolver.

This change introduces `BrokerLeaderWithResolver` and `BrokerForConsumerWithResolver` methods that check for an `AddressResolver` before attempting DNS lookup. When a resolver exists, these methods use the resolver's host and port directly, bypassing DNS resolution entirely.

The original `BrokerLeader` and `BrokerForConsumer` methods remain unchanged for backward compatibility and delegate to the new methods with a `nil` resolver parameter.