### PR TITLE
fix(ha): fix mutex stall, data race consumer in ReliablConsumer

### DIFF
--- a/examples/reliable/reliable_client.go
+++ b/examples/reliable/reliable_client.go
@@ -102,13 +102,13 @@ func main() {
 
 	// Tune the parameters to test the reliability
 	const messagesToSend = 3_000_000
-	const numberOfProducers = 5
-	const concurrentProducers = 2
+	const numberOfProducers = 2
+	const concurrentProducers = 1
 	const numberOfConsumers = 2
 	const sendDelay = 100 * time.Microsecond
 	const delayEachMessages = 500
 	const maxProducersPerClient = 2
-	const maxConsumersPerClient = 2
+	const maxConsumersPerClient = 5
 	//
 
 	reader := bufio.NewReader(os.Stdin)
@@ -118,8 +118,8 @@ func main() {
 	fmt.Printf("  Connecting to RabbitMQ streaming...\n\n")
 
 	//  in case of load-balancer you can use the AddressResolver
-	//  var resolver = stream.AddressResolver{
-	//	Host: "localhost",
+	//var resolver = stream.AddressResolver{
+	//	Host: "192.168.1.54",
 	//	Port: 5552,
 	//}
 
@@ -127,177 +127,181 @@ func main() {
 		stream.NewEnvironmentOptions().
 			SetMaxProducersPerClient(maxProducersPerClient).
 			SetMaxConsumersPerClient(maxConsumersPerClient).
-			SetHost("localhost").
 			SetUser("guest").
 			SetPassword("guest").
+			SetHost("localhost").
 			SetPort(5552))
-	//  SetHost(resolver.Host).
-	//  SetPort(resolver.Port).
-	//  SetAddressResolver(resolver))
+	//SetHost(resolver.Host).
+	//SetPort(resolver.Port).
+	//SetAddressResolver(resolver))
 
 	CheckErr(err)
 	fmt.Printf("  %sConnected%s  (max %d producers / %d consumers per client)\n\n",
 		ansiGreen, ansiReset, maxProducersPerClient, maxConsumersPerClient)
-
-	streamName := "golang-reliable-Test"
-
-	err = env.DeleteStream(streamName)
-	// If the stream does not exist,
-	// we don't care here as we are going to create it anyway
-	if !errors.Is(err, stream.StreamDoesNotExist) {
-		CheckErr(err)
-	}
-	err = env.DeclareStream(streamName,
-		&stream.StreamOptions{
-			MaxLengthBytes: stream.ByteCapacity{}.GB(10),
-		},
-	)
-	CheckErr(err)
-
 	producers := make([]*ha.ReliableProducer, 0, numberOfProducers)
 	consumers := make([]*ha.ReliableConsumer, 0, numberOfConsumers)
 	isRunning := true
-	go func() {
-		for isRunning {
-			totalConfirmed := atomic.LoadInt32(&confirmed) + atomic.LoadInt32(&fail)
-			expectedMessages := int32(messagesToSend * numberOfProducers * concurrentProducers * 2)
-			cfmd := atomic.LoadInt32(&confirmed)
-			failed := atomic.LoadInt32(&fail)
-			cons := atomic.LoadInt32(&consumed)
 
-			var confirmRate float64
-			if totalConfirmed > 0 {
-				confirmRate = float64(cfmd) / float64(totalConfirmed) * 100
-			}
-
-			perConsumer := int32(0)
-			if numberOfConsumers > 0 {
-				perConsumer = cons / numberOfConsumers
-			}
-
-			fmt.Print(clearScreen)
-
-			sep()
-			fmt.Printf("  %s%s  RabbitMQ Stream  ·  Reliable Client  %s\n", ansiBold, ansiMagenta, ansiReset)
-			sep()
-
-			fmt.Printf("\n  %-12s%s%s%s\n", "Stream", ansiBold, streamName, ansiReset)
-			fmt.Printf("  %-12s%s\n", "Time", time.Now().Format("Mon, 02 Jan 06 15:04:05 MST"))
-
-			sectionTitle("CONFIGURATION")
-			fmt.Printf("  Producers: %s%d%s   Concurrent: %s%d%s   Consumers: %s%d%s   Goroutines: %s%d%s\n",
-				ansiBold, numberOfProducers, ansiReset,
-				ansiBold, concurrentProducers, ansiReset,
-				ansiBold, numberOfConsumers, ansiReset,
-				ansiBold, runtime.NumGoroutine(), ansiReset,
-			)
-
-			sectionTitle("MESSAGES")
-			fmt.Printf("  Target  %s%-14s%s  Sent  %s%-14s%s  ReSent  %s%s%s\n",
-				ansiYellow, formatCommas(expectedMessages), ansiReset,
-				ansiGreen, formatCommas(sent), ansiReset,
-				ansiCyan, formatCommas(atomic.LoadInt32(&reSent)), ansiReset,
-			)
-
-			sectionTitle("CONFIRMATIONS")
-			fmt.Printf("  Confirmed  %s%-12s%s  Failed  %s%-12s%s  Total  %s%s%s\n",
-				ansiGreen, formatCommas(cfmd), ansiReset,
-				ansiRed, formatCommas(failed), ansiReset,
-				ansiDim, formatCommas(totalConfirmed), ansiReset,
-			)
-			fmt.Printf("  Rate  %s%.1f%%%s  %s\n",
-				ansiBold, confirmRate, ansiReset, progressBar(confirmRate, 30))
-
-			sectionTitle("CONSUMPTION")
-			fmt.Printf("  Total  %s%-14s%s  Per Consumer  %s%s%s\n",
-				ansiGreen, formatCommas(cons), ansiReset,
-				ansiBold, formatCommas(perConsumer), ansiReset,
-			)
-
-			sectionTitle(fmt.Sprintf("PRODUCERS (%d)", len(producers)))
-			for i, producer := range producers {
-				fmt.Printf("  [%d] %-40s  %s\n", i+1, producer.GetInfo(), colorStatus(producer.GetStatusAsString()))
-			}
-
-			sectionTitle(fmt.Sprintf("CONSUMERS (%d)", len(consumers)))
-			for i, consumer := range consumers {
-				fmt.Printf("  [%d] %-40s  %s\n", i+1, consumer.GetInfo(), colorStatus(consumer.GetStatusAsString()))
-			}
-
-			fmt.Println()
-			sep()
-
-			time.Sleep(5 * time.Second)
+	streamsName := []string{"golang-reliable-Test", "golang-reliable-Test-1", "golang-reliable-Test-2", "golang-reliable-Test-3"}
+	for _, streamName := range streamsName {
+		err = env.DeleteStream(streamName)
+		// If the stream does not exist,
+		// we don't care here as we are going to create it anyway
+		if !errors.Is(err, stream.StreamDoesNotExist) {
+			CheckErr(err)
 		}
-	}()
-
-	for range numberOfConsumers {
-		consumer, err := ha.NewReliableConsumer(env,
-			streamName,
-			stream.NewConsumerOptions().SetOffset(stream.OffsetSpecification{}.First()),
-			func(_ stream.ConsumerContext, _ *amqp.Message) {
-				atomic.AddInt32(&consumed, 1)
-			})
+		err = env.DeclareStream(streamName,
+			&stream.StreamOptions{
+				MaxLengthBytes: stream.ByteCapacity{}.GB(10),
+			},
+		)
 		CheckErr(err)
-		consumers = append(consumers, consumer)
-	}
 
-	for i := 0; i < numberOfProducers; i++ {
-		var mutex = sync.Mutex{}
-		// Here we store the messages that have not been confirmed
-		// then we resend them.
-		// Note: This is only for test. The list can grow indefinitely
-		var unConfirmedMessages []message.StreamMessage
-		rProducer, err := ha.NewReliableProducer(env,
-			streamName,
-			stream.NewProducerOptions().
-				SetConfirmationTimeOut(2*time.Second).
-				SetClientProvidedName(fmt.Sprintf("producer-%d", i)),
-			func(messageStatus []*stream.ConfirmationStatus) {
-				go func() {
-					for _, msgStatus := range messageStatus {
-						if msgStatus.IsConfirmed() {
-							atomic.AddInt32(&confirmed, 1)
-						} else {
-							atomic.AddInt32(&fail, 1)
-							if enableResend {
-								mutex.Lock()
-								unConfirmedMessages = append(unConfirmedMessages, msgStatus.GetMessage())
-								mutex.Unlock()
-							}
-						}
-					}
-				}()
-			})
-		CheckErr(err)
-		producers = append(producers, rProducer)
 		go func() {
-			for i := 0; i < concurrentProducers; i++ {
-				go func() {
-					for i := 0; i < messagesToSend; i++ {
-						mutex.Lock()
-						for _, confirmedMessage := range unConfirmedMessages {
-							err := rProducer.Send(confirmedMessage)
-							atomic.AddInt32(&reSent, 1)
-							CheckErr(err)
-						}
-						unConfirmedMessages = []message.StreamMessage{}
-						mutex.Unlock()
-						msg := amqp.NewMessage([]byte("ha"))
-						err := rProducer.Send(msg)
-						if i%delayEachMessages == 0 {
-							time.Sleep(sendDelay)
-						}
-						atomic.AddInt32(&sent, 1)
-						CheckErr(err)
+			for isRunning {
+				totalConfirmed := atomic.LoadInt32(&confirmed) + atomic.LoadInt32(&fail)
+				expectedMessages := int32((messagesToSend * numberOfProducers * concurrentProducers * 2) * len(streamsName))
+				cfmd := atomic.LoadInt32(&confirmed)
+				failed := atomic.LoadInt32(&fail)
+				cons := atomic.LoadInt32(&consumed)
 
-						errBatch := rProducer.BatchSend([]message.StreamMessage{msg})
-						CheckErr(errBatch)
-						atomic.AddInt32(&sent, 1)
-					}
-				}()
+				var confirmRate float64
+				if totalConfirmed > 0 {
+					confirmRate = float64(cfmd) / float64(totalConfirmed) * 100
+				}
+
+				perConsumer := int32(0)
+				if numberOfConsumers > 0 {
+					perConsumer = cons / numberOfConsumers
+				}
+
+				fmt.Print(clearScreen)
+
+				sep()
+				fmt.Printf("  %s%s  RabbitMQ Stream  ·  Reliable Client  %s\n", ansiBold, ansiMagenta, ansiReset)
+				sep()
+
+				fmt.Printf("\n  %-12s%s%s%s\n", "Streams", ansiBold, streamsName, ansiReset)
+				fmt.Printf("  %-12s%s\n", "Time", time.Now().Format("Mon, 02 Jan 06 15:04:05 MST"))
+
+				sectionTitle("CONFIGURATION")
+				fmt.Printf("  Producers: %s%d%s   Concurrent: %s%d%s   Consumers: %s%d%s   Goroutines: %s%d%s\n",
+					ansiBold, numberOfProducers, ansiReset,
+					ansiBold, concurrentProducers, ansiReset,
+					ansiBold, numberOfConsumers, ansiReset,
+					ansiBold, runtime.NumGoroutine(), ansiReset,
+				)
+
+				sectionTitle("MESSAGES")
+				fmt.Printf("  Target  %s%-14s%s  Sent  %s%-14s%s  ReSent  %s%s%s\n",
+					ansiYellow, formatCommas(expectedMessages), ansiReset,
+					ansiGreen, formatCommas(sent), ansiReset,
+					ansiCyan, formatCommas(atomic.LoadInt32(&reSent)), ansiReset,
+				)
+
+				sectionTitle("CONFIRMATIONS")
+				fmt.Printf("  Confirmed  %s%-12s%s  Failed  %s%-12s%s  Total  %s%s%s\n",
+					ansiGreen, formatCommas(cfmd), ansiReset,
+					ansiRed, formatCommas(failed), ansiReset,
+					ansiDim, formatCommas(totalConfirmed), ansiReset,
+				)
+				fmt.Printf("  Rate  %s%.1f%%%s  %s\n",
+					ansiBold, confirmRate, ansiReset, progressBar(confirmRate, 30))
+
+				sectionTitle("CONSUMPTION")
+				fmt.Printf("  Total  %s%-14s%s  Per Consumer  %s%s%s\n",
+					ansiGreen, formatCommas(cons), ansiReset,
+					ansiBold, formatCommas(perConsumer), ansiReset,
+				)
+
+				sectionTitle(fmt.Sprintf("PRODUCERS (%d)", len(producers)))
+				for i, producer := range producers {
+					fmt.Printf("  [%d] %-40s  %s\n", i+1, producer.GetInfo(), colorStatus(producer.GetStatusAsString()))
+				}
+
+				sectionTitle(fmt.Sprintf("CONSUMERS (%d)", len(consumers)))
+				for i, consumer := range consumers {
+					fmt.Printf("  [%d] %-40s  %s\n", i+1, consumer.GetInfo(), colorStatus(consumer.GetStatusAsString()))
+				}
+
+				fmt.Println()
+				sep()
+
+				time.Sleep(5 * time.Second)
 			}
 		}()
+
+		for range numberOfConsumers {
+			consumer, err := ha.NewReliableConsumer(env,
+				streamName,
+				stream.NewConsumerOptions().SetOffset(stream.OffsetSpecification{}.First()),
+				func(ctx stream.ConsumerContext, _ *amqp.Message) {
+					atomic.AddInt32(&consumed, 1)
+					if ctx.Consumer.GetStreamName() != streamName {
+						panic(fmt.Sprintf("Received message for stream %s on consumer for stream %s", ctx.Consumer.GetStreamName(), streamName))
+					}
+				})
+			CheckErr(err)
+			consumers = append(consumers, consumer)
+		}
+
+		for i := 0; i < numberOfProducers; i++ {
+			var mutex = sync.Mutex{}
+			// Here we store the messages that have not been confirmed
+			// then we resend them.
+			// Note: This is only for test. The list can grow indefinitely
+			var unConfirmedMessages []message.StreamMessage
+			rProducer, err := ha.NewReliableProducer(env,
+				streamName,
+				stream.NewProducerOptions().
+					SetConfirmationTimeOut(2*time.Second).
+					SetClientProvidedName(fmt.Sprintf("producer-%d", i)),
+				func(messageStatus []*stream.ConfirmationStatus) {
+					go func() {
+						for _, msgStatus := range messageStatus {
+							if msgStatus.IsConfirmed() {
+								atomic.AddInt32(&confirmed, 1)
+							} else {
+								atomic.AddInt32(&fail, 1)
+								if enableResend {
+									mutex.Lock()
+									unConfirmedMessages = append(unConfirmedMessages, msgStatus.GetMessage())
+									mutex.Unlock()
+								}
+							}
+						}
+					}()
+				})
+			CheckErr(err)
+			producers = append(producers, rProducer)
+			go func() {
+				for i := 0; i < concurrentProducers; i++ {
+					go func() {
+						for i := 0; i < messagesToSend; i++ {
+							mutex.Lock()
+							for _, confirmedMessage := range unConfirmedMessages {
+								err := rProducer.Send(confirmedMessage)
+								atomic.AddInt32(&reSent, 1)
+								CheckErr(err)
+							}
+							unConfirmedMessages = []message.StreamMessage{}
+							mutex.Unlock()
+							msg := amqp.NewMessage([]byte("ha"))
+							err := rProducer.Send(msg)
+							if i%delayEachMessages == 0 {
+								time.Sleep(sendDelay)
+							}
+							atomic.AddInt32(&sent, 1)
+							CheckErr(err)
+
+							errBatch := rProducer.BatchSend([]message.StreamMessage{msg})
+							CheckErr(errBatch)
+							atomic.AddInt32(&sent, 1)
+						}
+					}()
+				}
+			}()
+		}
 	}
 
 	fmt.Printf("\n  %sPress enter to close the connections.%s\n", ansiDim, ansiReset)

--- a/examples/reliable/reliable_client.go
+++ b/examples/reliable/reliable_client.go
@@ -118,10 +118,10 @@ func main() {
 	fmt.Printf("  Connecting to RabbitMQ streaming...\n\n")
 
 	//  in case of load-balancer you can use the AddressResolver
-	//var resolver = stream.AddressResolver{
+	// var resolver = stream.AddressResolver{
 	//	Host: "192.168.1.54",
 	//	Port: 5552,
-	//}
+	// }
 
 	env, err := stream.NewEnvironment(
 		stream.NewEnvironmentOptions().
@@ -131,9 +131,9 @@ func main() {
 			SetPassword("guest").
 			SetHost("localhost").
 			SetPort(5552))
-	//SetHost(resolver.Host).
-	//SetPort(resolver.Port).
-	//SetAddressResolver(resolver))
+	// SetHost(resolver.Host).
+	// SetPort(resolver.Port).
+	// SetAddressResolver(resolver))
 
 	CheckErr(err)
 	fmt.Printf("  %sConnected%s  (max %d producers / %d consumers per client)\n\n",

--- a/pkg/ha/ha_consumer.go
+++ b/pkg/ha/ha_consumer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
@@ -22,7 +23,12 @@ type ReliableConsumer struct {
 	mutexConnection *sync.Mutex
 	status          int
 	messagesHandler stream.MessagesHandler
-	currentPosition int64 // the last offset consumed. It is needed in case of restart
+	// currentPosition is updated atomically on every message delivery and read
+	// without a lock in newConsumer(), so it must not be moved into mutexConnection's
+	// critical section. See Issue-1 analysis: holding mutexConnection across the
+	// blocking env.NewConsumer() call while the handler closure also needed that
+	// same lock was the source of the stall.
+	currentPosition atomic.Int64
 
 	//bootstrap: if true the consumer will start from the user offset.
 	// If false it will start from the last offset consumed (currentPosition)
@@ -46,7 +52,26 @@ func (c *ReliableConsumer) handleNotifyClose(channelClose stream.ChannelClose) {
 					"[Reliable] - %s won't be reconnected. Error: %s", c.getInfo(), err)
 			}
 			if reconnected {
-				c.setStatus(StatusOpen)
+				// Close() may have been called while retry() was running (backoff
+				// can be many seconds). Use mutexStatus to atomically decide:
+				// if the user already closed us, keep StatusClosed and clean up
+				// the new consumer that newConsumer() just created.
+				c.mutexStatus.Lock()
+				alreadyClosed := c.status == StatusClosed
+				if !alreadyClosed {
+					c.status = StatusOpen
+				}
+				c.mutexStatus.Unlock()
+
+				if alreadyClosed {
+					c.mutexConnection.Lock()
+					consumer := c.consumer
+					c.mutexConnection.Unlock()
+					if consumer != nil {
+						_ = consumer.Close()
+					}
+					logs.LogInfo("[Reliable] - %s reconnected but was explicitly closed during reconnection. Closing new consumer.", c.getInfo())
+				}
 			} else {
 				c.setStatus(StatusClosed)
 			}
@@ -66,7 +91,6 @@ func NewReliableConsumer(env *stream.Environment, streamName string,
 		mutexStatus:     &sync.Mutex{},
 		mutexConnection: &sync.Mutex{},
 		messagesHandler: messagesHandler,
-		currentPosition: 0,
 		bootstrap:       true,
 	}
 	if messagesHandler == nil {
@@ -118,19 +142,22 @@ func (c *ReliableConsumer) getTimeOut() time.Duration {
 }
 
 func (c *ReliableConsumer) newConsumer() error {
-	c.mutexConnection.Lock()
-	defer c.mutexConnection.Unlock()
-	offset := stream.OffsetSpecification{}.Offset(c.currentPosition + 1)
+	// Read the current position atomically before the blocking subscribe call.
+	// mutexConnection is NOT held here: env.NewConsumer() is a blocking network
+	// operation (subscribe frame + server ack), and the message handler closure
+	// registered below also needs mutexConnection for c.consumer access.
+	// Holding the lock across that call created a stall where the consumer
+	// dispatch goroutine (which runs the handler) was blocked on mutexConnection
+	// while the read loop's sendChunk() could fill chunkForConsumer and block too.
+	offset := stream.OffsetSpecification{}.Offset(c.currentPosition.Load() + 1)
 	if c.bootstrap {
 		offset = c.consumerOptions.Offset
 	}
 	logs.LogDebug("[Reliable] - creating %s. Boot: %s. StartOffset: %s", c.getInfo(),
 		c.bootstrap, offset)
 	consumer, err := c.env.NewConsumer(c.streamName, func(consumerContext stream.ConsumerContext, message *amqp.Message) {
-		c.mutexConnection.Lock()
-		c.currentPosition = consumerContext.Consumer.GetOffset()
-		c.mutexConnection.Unlock()
-
+		// currentPosition is an atomic.Int64; no mutex required here.
+		c.currentPosition.Store(consumerContext.Consumer.GetOffset())
 		c.messagesHandler(consumerContext, message)
 	}, c.consumerOptions.SetOffset(offset))
 	if err != nil {
@@ -139,17 +166,25 @@ func (c *ReliableConsumer) newConsumer() error {
 
 	channelNotifyClose := consumer.NotifyClose()
 	c.handleNotifyClose(channelNotifyClose)
+	// Only lock briefly to publish the new consumer reference.
+	c.mutexConnection.Lock()
 	c.consumer = consumer
-	return err
+	c.mutexConnection.Unlock()
+	return nil
 }
 
 func (c *ReliableConsumer) Close() error {
 	c.setStatus(StatusClosed)
-	err := c.consumer.Close()
-	if err != nil {
-		return err
+	// Snapshot the pointer under the lock to avoid a data race with newConsumer(),
+	// which writes c.consumer under mutexConnection. The Close() call itself is
+	// made outside the lock so we don't hold it across a blocking network operation.
+	c.mutexConnection.Lock()
+	consumer := c.consumer
+	c.mutexConnection.Unlock()
+	if consumer == nil {
+		return nil
 	}
-	return nil
+	return consumer.Close()
 }
 
 func (c *ReliableConsumer) GetInfo() string {


### PR DESCRIPTION


Three concurrency bugs addressed in ReliableConsumer:

1. Stall risk: mutexConnection was held across the entire env.NewConsumer() call (a blocking network round-trip). The message handler closure registered inside that same call also needed the lock, so the consumer dispatch goroutine could block waiting for it immediately after subscription, causing sendChunk() in the read loop to fill chunkForConsumer and stall too. Fixed by switching currentPosition to atomic.Int64 (no mutex needed in the handler) and narrowing mutexConnection to only the final c.consumer assignment.

2. Data race: Close() read c.consumer without holding mutexConnection while newConsumer() writes it under that lock. Fixed by snapshotting the pointer under the lock and calling Close() on the snapshot outside the lock.

3. Zombie consumer: if Close() was called while retry() was sleeping through its backoff, a successful reconnection would overwrite StatusClosed with StatusOpen, leaving a new consumer running after an explicit close. Fixed by using a CAS-like check under mutexStatus after retry() returns: if the status is already StatusClosed, the newly created consumer is closed and the status is left unchanged.