### PR TITLE
perf(consumer): reuse the chunk buffer, the readers and the metric attributes in handleDeliver

### DIFF
--- a/pkg/stream/client.go
+++ b/pkg/stream/client.go
@@ -93,6 +93,24 @@ type Client struct {
 
 	doneTimeoutTicker chan struct{}
 	metrics           *streamMetrics
+
+	// deliverChunk is the payload of the chunk handleDeliver is reading, and
+	// deliverBytes/deliverReader are the readers over it. All three are
+	// reused from chunk to chunk: handleResponse is the only goroutine that
+	// ever touches them, and nothing outlives the call -- decodeMessage
+	// copies every record out of the chunk before it returns. Allocating a
+	// payload buffer and a bufio.Reader per chunk instead was 12% of
+	// everything a consumer-heavy application allocated. What is retained
+	// per connection in exchange is one chunk's worth of payload -- bounded
+	// by the negotiated frame size -- plus one 4 KiB read buffer.
+	deliverChunk  []byte
+	deliverBytes  *bytes.Reader
+	deliverReader *bufio.Reader
+
+	// consumerAttributes memoises otelAttributesForConsumer per stream. The
+	// set cannot change for a given broker and stream, and it was being
+	// rebuilt twice for every chunk delivered.
+	consumerAttributes *sync.Map
 }
 
 func newClient(parameters connectionParameters) *Client {
@@ -128,7 +146,11 @@ func newClient(parameters connectionParameters) *Client {
 		availableFeatures: newAvailableFeatures(),
 		doneTimeoutTicker: make(chan struct{}, 1),
 		metrics:           parameters.metrics,
+
+		deliverBytes:       bytes.NewReader(nil),
+		consumerAttributes: &sync.Map{},
 	}
+	c.deliverReader = bufio.NewReader(c.deliverBytes)
 	c.setConnectionName(parameters.connectionName)
 	return c
 }
@@ -1283,7 +1305,16 @@ func (c *Client) otelAttributesForConfirm() attribute.Set {
 }
 
 func (c *Client) otelAttributesForConsumer(streamName string) attribute.Set {
+	if cached, ok := c.consumerAttributes.Load(streamName); ok {
+		if set, ok := cached.(attribute.Set); ok {
+			return set
+		}
+	}
+
 	attrs := c.otelBaseAttributes()
 	attrs = append(attrs, semconv.MessagingOperationTypeReceive, semconv.MessagingOperationName("deliver"), semconv.MessagingDestinationName(streamName))
-	return attribute.NewSet(attrs...)
+	set := attribute.NewSet(attrs...)
+	c.consumerAttributes.Store(streamName, set)
+
+	return set
 }

--- a/pkg/stream/server_frame.go
+++ b/pkg/stream/server_frame.go
@@ -312,7 +312,13 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 
 	var offsetLimit int64 = -1
 
-	var bytesBuffer = make([]byte, int(dataLength))
+	// The payload buffer is the client's, reused from chunk to chunk: see
+	// Client.deliverChunk. Every record is copied out of it before this
+	// function returns, so nothing holds a window into it afterwards.
+	if cap(c.deliverChunk) < int(dataLength) {
+		c.deliverChunk = make([]byte, int(dataLength))
+	}
+	bytesBuffer := c.deliverChunk[:int(dataLength)]
 	_, err = io.ReadFull(r, bytesBuffer)
 	logErrorCommand(err, "handleDeliver")
 
@@ -359,8 +365,9 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 		}
 	}
 
-	bufferReader := bytes.NewReader(bytesBuffer)
-	dataReader := bufio.NewReader(bufferReader)
+	c.deliverBytes.Reset(bytesBuffer)
+	c.deliverReader.Reset(c.deliverBytes)
+	dataReader := c.deliverReader
 
 	remainingRecords := numRecords
 	for remainingRecords != 0 {
@@ -417,8 +424,9 @@ func (c *Client) handleDeliver(r *bufio.Reader) {
 			"Messages won't be dispatched", consumer.GetName(), consumer.GetStreamName())
 		return
 	}
-	c.metrics.consumed(context.Background(), int64(numRecords), c.otelAttributesForConsumer(consumer.GetStreamName()))
-	c.metrics.chunkReceived(context.Background(), int64(numRecords), c.otelAttributesForConsumer(consumer.GetStreamName()))
+	consumerAttributes := c.otelAttributesForConsumer(consumer.GetStreamName())
+	c.metrics.consumed(context.Background(), int64(numRecords), consumerAttributes)
+	c.metrics.chunkReceived(context.Background(), int64(numRecords), consumerAttributes)
 }
 
 func (c *Client) decodeMessage(r *bufio.Reader, filter bool, offset int64, offsetLimit int64, batchConsumingMessages offsetMessages) offsetMessages {

--- a/pkg/stream/server_frame_bench_test.go
+++ b/pkg/stream/server_frame_bench_test.go
@@ -1,0 +1,104 @@
+package stream
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"hash/crc32"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// deliverFrame builds the body of one Deliver frame -- everything
+// handleDeliver reads, starting at the subscription id -- carrying records
+// plain (uncompressed, unfiltered) entries of bodySize bytes each.
+func deliverFrame(tb testing.TB, records int, bodySize int) []byte {
+	tb.Helper()
+
+	encoded, err := amqp.NewMessage(bytes.Repeat([]byte("x"), bodySize)).MarshalBinary()
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	payload := &bytes.Buffer{}
+	for range records {
+		writeUInt(payload, uint32(len(encoded)))
+		payload.Write(encoded)
+	}
+
+	frame := &bytes.Buffer{}
+	writeByte(frame, 0)                 // subscription id
+	writeByte(frame, 0)                 // magic and version, skipped
+	writeByte(frame, 0)                 // chunk type
+	writeUShort(frame, uint16(records)) // num entries
+	writeUInt(frame, uint32(records))   // num records
+	writeLong(frame, time.Now().Unix()) // timestamp
+	writeLong(frame, 0)                 // epoch
+	writeLong(frame, 0)                 // offset
+	writeUInt(frame, crc32.ChecksumIEEE(payload.Bytes()))
+	writeUInt(frame, uint32(payload.Len()))
+	writeUInt(frame, 0) // reserved
+	writeUInt(frame, 0) // reserved
+	frame.Write(payload.Bytes())
+
+	return frame.Bytes()
+}
+
+// BenchmarkHandleDeliver prices one delivered chunk on the consumer side: the
+// payload buffer, the readers over it, the decoded messages and the metric
+// attributes. It is the per-message cost of consuming, so the allocations
+// here are the ones a busy consumer pays for every message off the wire.
+func BenchmarkHandleDeliver(b *testing.B) {
+	for _, records := range []int{1, 20, 100} {
+		b.Run(fmt.Sprintf("records=%d", records), func(b *testing.B) {
+			metrics, err := newStreamMetrics(noop.NewMeterProvider())
+			if err != nil {
+				b.Fatal(err)
+			}
+			client := newClient(connectionParameters{
+				broker:     newBrokerDefault(),
+				rpcTimeout: time.Second,
+				metrics:    metrics,
+			})
+			consumer, err := client.coordinator.NewConsumer(nil, &ConsumerOptions{
+				streamName:     "bench",
+				Offset:         OffsetSpecification{}.Last(),
+				initialCredits: 10,
+				CRCCheck:       true,
+			}, func() {})
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// The dispatch goroutine is not running, so the chunks have to be
+			// taken off the consumer's channel here or handleDeliver blocks.
+			done := make(chan struct{})
+			defer close(done)
+			go func() {
+				for {
+					select {
+					case <-consumer.chunkForConsumer:
+					case <-done:
+						return
+					}
+				}
+			}()
+
+			frame := deliverFrame(b, records, 1024)
+			source := bytes.NewReader(frame)
+			reader := bufio.NewReader(source)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(frame)))
+			b.ResetTimer()
+			for b.Loop() {
+				source.Reset(frame)
+				reader.Reset(source)
+				client.handleDeliver(reader)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

`handleDeliver` allocates, for every chunk delivered:

- the chunk payload buffer — `make([]byte, dataLength)`;
- a `bytes.Reader` and a `bufio.Reader` (with its 4 KiB buffer) over that buffer;
- two `attribute.Set`s, built from scratch and identical for the life of the consumer.

None of it has to be per chunk. This moves all three onto the `Client` and reuses them.

### Why it is safe

- `handleResponse` is the only goroutine that reads a connection's frames and it calls `handleDeliver` synchronously, so the reused state has a single owner.
- Nothing keeps a window into the payload once `handleDeliver` returns: `decodeMessage` copies every record out of it via `readUint8Array`, and `Message.UnmarshalBinary` clones the data section again. The `chunkInfo` dispatched to the consumer holds only those copies.
- `otelAttributesForConsumer` cannot change for a given broker and stream, so it is memoised per stream and now built once per chunk instead of twice.

What a connection retains in exchange is one chunk's worth of payload — bounded by the negotiated frame size — plus one 4 KiB read buffer.

### Numbers

The first commit adds `BenchmarkHandleDeliver`, which drives one synthetic Deliver frame through `handleDeliver`; the second is the change. 1 KiB messages, `-benchtime=1500x -count=5`, linux/amd64:

| entries per chunk | before | after |
| --- | --- | --- |
| 1 | 9 640 B/op, 39 allocs/op | 2 585 B/op, 27 allocs/op |
| 20 | 76 080 B/op, 191 allocs/op | 48 431 B/op, 179 allocs/op |
| 100 | 353 874 B/op, 831 allocs/op | 241 546 B/op, 819 allocs/op |

12 allocations per chunk go away whatever the chunk size; the bytes saved grow with the payload, because the payload buffer is the largest of the three.

Wall-clock improves too, most visibly on small chunks (~10.4 µs → ~3.4 µs at one entry on my laptop), but that machine is too noisy for me to want to quote it as a result.

### How it was found

Profiling a consumer of a partitioned sport-event stream: these three sites were **14% of every byte the process allocated** (~33 GB/h out of 238 GB/h), second only to the application's own Snappy decompression.

### Testing

`make NUM_PROCS=4 test` against a broker built from `.ci/Dockerfile`: 229/230 specs pass on this branch. The suite is flaky on my machine either way — the one failure on this branch was "offset should not be overwritten by autocommit on consumer close when no messages have been consumed", and a run of unpatched `main` on the same box also came out 229/230, failing a different spec ("Multi-thread NewProducer/Send"). Both pass in isolation.

`golangci-lint run ./pkg/stream/...` (v2.6, as in CI) reports nothing on the changed files.
