### PR TITLE
Retain early close notifications and make lifecycle shutdown race-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Bug Fixes
+- Retain producer, consumer, and super stream partition close events emitted before notification registration; repeated registration returns the same channel.
+- Publish HA client state before processing retained notifications, and drain terminal super stream notifications without reconnecting.
+- Prevent concurrent producer closes from running teardown more than once, and finish or cancel pending partition forwarders before closing super stream consumer notifications.
+
 ## [[1.8.3](https://github.com/rabbitmq/rabbitmq-stream-go-client/releases/tag/v1.8.3)]
 
 ## 1.8.3 - 2026-07-23

--- a/examples/reliable/reliable_client.go
+++ b/examples/reliable/reliable_client.go
@@ -101,7 +101,7 @@ func main() {
 	}()
 
 	// Tune the parameters to test the reliability
-	const messagesToSend = 10_000_000
+	const messagesToSend = 20_000_000
 	const numberOfProducers = 2
 	const concurrentProducers = 1
 	const numberOfConsumers = 2
@@ -114,6 +114,7 @@ func main() {
 	const numberOfPartitions = 3
 	const superStreamName = "golang-reliable-super-stream-Test"
 	//
+	streamsName := []string{"golang-reliable-Test", "golang-reliable-Test-1", "golang-reliable-Test-2"}
 
 	reader := bufio.NewReader(os.Stdin)
 	stream.SetLevelInfo(logs.INFO)
@@ -148,7 +149,6 @@ func main() {
 	superConsumers := make([]*ha.ReliableSuperStreamConsumer, 0, numberOfConsumers)
 	isRunning := true
 
-	streamsName := []string{"golang-reliable-Test", "golang-reliable-Test-1", "golang-reliable-Test-2", "golang-reliable-Test-3"}
 	for _, streamName := range streamsName {
 		err = env.DeleteStream(streamName)
 		// If the stream does not exist,

--- a/examples/reliable/reliable_client.go
+++ b/examples/reliable/reliable_client.go
@@ -133,8 +133,8 @@ func main() {
 			SetMaxConsumersPerClient(maxConsumersPerClient).
 			SetUser("guest").
 			SetPassword("guest").
-			//SetHost("localhost").
-			//SetPort(5552))
+			// SetHost("localhost").
+			// SetPort(5552))
 			SetHost(resolver.Host).
 			SetPort(resolver.Port).
 			SetAddressResolver(resolver))

--- a/examples/super_stream/producer/super_stream_producer.go
+++ b/examples/super_stream/producer/super_stream_producer.go
@@ -98,7 +98,7 @@ func main() {
 				}
 			}
 		}
-	}(superStreamProducer.NotifyPublishConfirmation(1))
+	}(superStreamProducer.NotifyPublishConfirmation(0))
 
 	// Publish messages
 loop:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	golang.org/x/text v0.41.0
@@ -20,6 +21,7 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/frankban/quicktest v1.14.6 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250923004556-9e5a51aed1e8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
@@ -35,4 +38,5 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cobra v1.10.2
-	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	golang.org/x/text v0.41.0
@@ -21,7 +20,6 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/frankban/quicktest v1.14.6 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -29,7 +27,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250923004556-9e5a51aed1e8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
@@ -38,5 +35,4 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/ha/close_notification_test.go
+++ b/pkg/ha/close_notification_test.go
@@ -2,37 +2,12 @@ package ha
 
 import (
 	"sync"
-	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestSuperStreamDrainsTerminalPartitionEvents(t *testing.T) {
-	r := &ReliableSuperStreamConsumer{consumerOptions: stream.NewSuperStreamConsumerOptions(), mutexStatus: &sync.Mutex{}, status: StatusOpen}
-	events := make(chan stream.CPartitionClose, 1)
-	r.handleNotifyClose(events)
-	sent := make(chan struct{})
-	go func() {
-		defer close(sent)
-		defer close(events)
-		// A terminal event followed by unexpected closes must be drained without
-		// starting reconnection against this deliberately absent environment.
-		events <- stream.CPartitionClose{Event: stream.Event{Reason: stream.UnSubscribe}}
-		for range 4 {
-			events <- stream.CPartitionClose{Event: stream.Event{Reason: stream.SocketClosed}}
-		}
-	}()
-	select {
-	case <-sent:
-	case <-time.After(time.Second):
-		t.Fatal("HA listener abandoned pending partition events")
-	}
-	require.Eventually(t, func() bool { return r.GetStatus() == StatusClosed }, time.Second, time.Millisecond)
-	assert.Equal(t, StatusClosed, r.GetStatus())
-}
 
 // Embedding the real reliable consumer retains its shutdown behavior while
 // exposing the exact point at which retry enters backoff, without a broker.
@@ -49,31 +24,65 @@ func (r *retryCloseConsumer) getInfo() string {
 	return "close-during-retry"
 }
 
-func TestSuperStreamCloseInterruptsRetryBackoff(t *testing.T) {
-	r := &ReliableSuperStreamConsumer{consumerOptions: stream.NewSuperStreamConsumerOptions(), mutexStatus: &sync.Mutex{}, status: StatusReconnecting, stopRetry: make(chan struct{})}
-	r.consumer.Store(&stream.SuperStreamConsumer{})
-	observer := &retryCloseConsumer{ReliableSuperStreamConsumer: r, entered: make(chan struct{}, 1)}
-	finished := make(chan error, 1)
-	go func() {
-		err, connected := retry(1, observer, "events-0")
-		if connected {
-			finished <- nil
-		} else {
-			finished <- err
+var _ = Describe("Reliable Super Stream Consumer shutdown", func() {
+	It("drains terminal partition events", func() {
+		r := &ReliableSuperStreamConsumer{
+			consumerOptions: stream.NewSuperStreamConsumerOptions(),
+			mutexStatus:     &sync.Mutex{},
+			status:          StatusOpen,
 		}
-	}()
-	select {
-	case <-observer.entered:
-	case <-time.After(time.Second):
-		t.Fatal("retry did not enter backoff")
-	}
-	require.NoError(t, r.Close())
-	select {
-	case err := <-finished:
-		require.ErrorIs(t, err, stream.AlreadyClosed)
-	case <-time.After(time.Second):
-		t.Fatal("terminal Close did not stop pending retry")
-	}
-	assert.Equal(t, StatusClosed, r.GetStatus())
-	require.NoError(t, r.Close())
-}
+		events := make(chan stream.CPartitionClose, 1)
+		r.handleNotifyClose(events)
+
+		sent := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(sent)
+			defer close(events)
+			// A terminal event followed by unexpected closes must be drained without
+			// starting reconnection against this deliberately absent environment.
+			events <- stream.CPartitionClose{Event: stream.Event{Reason: stream.UnSubscribe}}
+			for range 4 {
+				events <- stream.CPartitionClose{Event: stream.Event{Reason: stream.SocketClosed}}
+			}
+		}()
+
+		Eventually(sent, time.Second).Should(BeClosed(),
+			"HA listener abandoned pending partition events")
+		Eventually(r.GetStatus).WithTimeout(time.Second).WithPolling(time.Millisecond).
+			Should(Equal(StatusClosed))
+	})
+
+	It("interrupts retry backoff on a terminal Close", func() {
+		r := &ReliableSuperStreamConsumer{
+			consumerOptions: stream.NewSuperStreamConsumerOptions(),
+			mutexStatus:     &sync.Mutex{},
+			status:          StatusReconnecting,
+			stopRetry:       make(chan struct{}),
+		}
+		r.consumer.Store(&stream.SuperStreamConsumer{})
+		observer := &retryCloseConsumer{ReliableSuperStreamConsumer: r, entered: make(chan struct{}, 1)}
+
+		finished := make(chan error, 1)
+		go func() {
+			defer GinkgoRecover()
+			err, connected := retry(1, observer, "events-0")
+			if connected {
+				finished <- nil
+			} else {
+				finished <- err
+			}
+		}()
+
+		Eventually(observer.entered, time.Second).Should(Receive(), "retry did not enter backoff")
+		Expect(r.Close()).To(Succeed())
+
+		var err error
+		Eventually(finished, time.Second).Should(Receive(&err),
+			"terminal Close did not stop pending retry")
+		Expect(err).To(MatchError(stream.AlreadyClosed))
+
+		Expect(r.GetStatus()).To(Equal(StatusClosed))
+		Expect(r.Close()).To(Succeed(), "Close must be idempotent")
+	})
+})

--- a/pkg/ha/close_notification_test.go
+++ b/pkg/ha/close_notification_test.go
@@ -1,0 +1,79 @@
+package ha
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuperStreamDrainsTerminalPartitionEvents(t *testing.T) {
+	r := &ReliableSuperStreamConsumer{consumerOptions: stream.NewSuperStreamConsumerOptions(), mutexStatus: &sync.Mutex{}, status: StatusOpen}
+	events := make(chan stream.CPartitionClose, 1)
+	r.handleNotifyClose(events)
+	sent := make(chan struct{})
+	go func() {
+		defer close(sent)
+		defer close(events)
+		// A terminal event followed by unexpected closes must be drained without
+		// starting reconnection against this deliberately absent environment.
+		events <- stream.CPartitionClose{Event: stream.Event{Reason: stream.UnSubscribe}}
+		for range 4 {
+			events <- stream.CPartitionClose{Event: stream.Event{Reason: stream.SocketClosed}}
+		}
+	}()
+	select {
+	case <-sent:
+	case <-time.After(time.Second):
+		t.Fatal("HA listener abandoned pending partition events")
+	}
+	require.Eventually(t, func() bool { return r.GetStatus() == StatusClosed }, time.Second, time.Millisecond)
+	assert.Equal(t, StatusClosed, r.GetStatus())
+}
+
+// Embedding the real reliable consumer retains its shutdown behavior while
+// exposing the exact point at which retry enters backoff, without a broker.
+type retryCloseConsumer struct {
+	*ReliableSuperStreamConsumer
+	entered chan struct{}
+}
+
+func (r *retryCloseConsumer) getInfo() string {
+	select {
+	case r.entered <- struct{}{}:
+	default:
+	}
+	return "close-during-retry"
+}
+
+func TestSuperStreamCloseInterruptsRetryBackoff(t *testing.T) {
+	r := &ReliableSuperStreamConsumer{consumerOptions: stream.NewSuperStreamConsumerOptions(), mutexStatus: &sync.Mutex{}, status: StatusReconnecting, stopRetry: make(chan struct{})}
+	r.consumer.Store(&stream.SuperStreamConsumer{})
+	observer := &retryCloseConsumer{ReliableSuperStreamConsumer: r, entered: make(chan struct{}, 1)}
+	finished := make(chan error, 1)
+	go func() {
+		err, connected := retry(1, observer, "events-0")
+		if connected {
+			finished <- nil
+		} else {
+			finished <- err
+		}
+	}()
+	select {
+	case <-observer.entered:
+	case <-time.After(time.Second):
+		t.Fatal("retry did not enter backoff")
+	}
+	require.NoError(t, r.Close())
+	select {
+	case err := <-finished:
+		require.ErrorIs(t, err, stream.AlreadyClosed)
+	case <-time.After(time.Second):
+		t.Fatal("terminal Close did not stop pending retry")
+	}
+	assert.Equal(t, StatusClosed, r.GetStatus())
+	require.NoError(t, r.Close())
+}

--- a/pkg/ha/ha_consumer.go
+++ b/pkg/ha/ha_consumer.go
@@ -100,9 +100,11 @@ func NewReliableConsumer(env *stream.Environment, streamName string,
 		return nil, fmt.Errorf("the consumer options is mandatory")
 	}
 	logs.LogDebug("[Reliable] - creating %s", res.getInfo())
+	// Publish initial state before newConsumer starts its close listener.
+	res.setStatus(StatusOpen)
 	err := res.newConsumer()
-	if err == nil {
-		res.setStatus(StatusOpen)
+	if err != nil {
+		res.setStatus(StatusClosed)
 	}
 	logs.LogDebug("[Reliable] - created %s", res.getInfo())
 	return res, err
@@ -164,12 +166,11 @@ func (c *ReliableConsumer) newConsumer() error {
 		return err
 	}
 
-	channelNotifyClose := consumer.NotifyClose()
-	c.handleNotifyClose(channelNotifyClose)
 	// Only lock briefly to publish the new consumer reference.
 	c.mutexConnection.Lock()
 	c.consumer = consumer
 	c.mutexConnection.Unlock()
+	c.handleNotifyClose(consumer.NotifyClose())
 	return nil
 }
 

--- a/pkg/ha/ha_publisher.go
+++ b/pkg/ha/ha_publisher.go
@@ -91,9 +91,11 @@ func NewReliableProducer(env *stream.Environment, streamName string,
 		return nil, fmt.Errorf("the producer options is mandatory")
 	}
 
+	// Publish initial state before newProducer starts its close listener.
+	res.setStatus(StatusOpen)
 	err := res.newProducer()
-	if err == nil {
-		res.setStatus(StatusOpen)
+	if err != nil {
+		res.setStatus(StatusClosed)
 	}
 	return res, err
 }
@@ -107,8 +109,8 @@ func (p *ReliableProducer) newProducer() error {
 	}
 	p.handlePublishConfirm(producer.NotifyPublishConfirmation())
 	channelNotifyClose := producer.NotifyClose()
-	p.handleNotifyClose(channelNotifyClose)
 	p.producer = producer
+	p.handleNotifyClose(channelNotifyClose)
 	return err
 }
 

--- a/pkg/ha/ha_super_stream_consumer.go
+++ b/pkg/ha/ha_super_stream_consumer.go
@@ -26,7 +26,9 @@ type ReliableSuperStreamConsumer struct {
 
 	//bootstrap: if true the consumer will start from the user offset.
 	// If false it will start from the last offset consumed (currentPosition)
-	bootstrap bool
+	bootstrap    bool
+	stopRetry    chan struct{}
+	retryStopped bool
 }
 
 func NewReliableSuperStreamConsumer(env *stream.Environment, superStream string, messagesHandler stream.MessagesHandler, consumerOptions *stream.SuperStreamConsumerOptions) (*ReliableSuperStreamConsumer, error) {
@@ -46,6 +48,7 @@ func NewReliableSuperStreamConsumer(env *stream.Environment, superStream string,
 		mutexStatus:     &sync.Mutex{},
 		messagesHandler: messagesHandler,
 		status:          StatusClosed,
+		stopRetry:       make(chan struct{}),
 	}
 	consumer, err := env.NewSuperStreamConsumer(superStream, func(consumerContext stream.ConsumerContext, message *amqp.Message) {
 		res.streamPositionMap.Store(consumerContext.Consumer.GetStreamName(), consumerContext.Consumer.GetOffset())
@@ -54,10 +57,10 @@ func NewReliableSuperStreamConsumer(env *stream.Environment, superStream string,
 	if err != nil {
 		return nil, fmt.Errorf("error creating super stream consumer: %w", err)
 	}
-	ch := consumer.NotifyPartitionClose(1)
-	res.handleNotifyClose(ch)
 	res.consumer.Store(consumer)
 	res.setStatus(StatusOpen)
+	ch := consumer.NotifyPartitionClose(1)
+	res.handleNotifyClose(ch)
 	logs.LogDebug("[Reliable] - creating %s", res.getInfo())
 	return res, err
 }
@@ -66,8 +69,19 @@ func (r *ReliableSuperStreamConsumer) handleNotifyClose(channelClose chan stream
 	go func() {
 		// for channelClose until closed
 		for cPartitionClose := range channelClose {
-			if strings.EqualFold(cPartitionClose.Event.Reason, stream.SocketClosed) || strings.EqualFold(cPartitionClose.Event.Reason, stream.MetaDataUpdate) || strings.EqualFold(cPartitionClose.Event.Reason, stream.ZombieConsumer) {
-				r.setStatus(StatusReconnecting)
+			// Close and the decision to reconnect share the status lock, so a
+			// queued event cannot reopen a consumer after terminal shutdown.
+			r.mutexStatus.Lock()
+			if r.status == StatusClosed {
+				r.mutexStatus.Unlock()
+				continue
+			}
+			unexpected := strings.EqualFold(cPartitionClose.Event.Reason, stream.SocketClosed) || strings.EqualFold(cPartitionClose.Event.Reason, stream.MetaDataUpdate) || strings.EqualFold(cPartitionClose.Event.Reason, stream.ZombieConsumer)
+			if unexpected {
+				r.status = StatusReconnecting
+			}
+			r.mutexStatus.Unlock()
+			if unexpected {
 				logs.LogWarn("[Reliable] - %s closed unexpectedly %s.. Reconnecting..", r.getInfo(), cPartitionClose.Event.Reason)
 				r.bootstrap = false
 				err, reconnected := retry(1, r, cPartitionClose.Partition)
@@ -76,14 +90,22 @@ func (r *ReliableSuperStreamConsumer) handleNotifyClose(channelClose chan stream
 						"[Reliable] - %s won't be reconnected. Error: %s", r.getInfo(), err)
 				}
 				if reconnected {
-					r.setStatus(StatusOpen)
+					r.mutexStatus.Lock()
+					alreadyClosed := r.status == StatusClosed
+					if !alreadyClosed {
+						r.status = StatusOpen
+					}
+					r.mutexStatus.Unlock()
+					if alreadyClosed {
+						_ = r.consumer.Load().Close()
+					}
 				} else {
 					r.setStatus(StatusClosed)
 				}
 			} else {
 				logs.LogInfo("[Reliable] - %s closed normally. Reason: %s", r.getInfo(), cPartitionClose.Event.Reason)
 				r.setStatus(StatusClosed)
-				break
+				continue
 			}
 		}
 		logs.LogDebug("[ReliableSuperStreamConsumer] - cPartitionClose closed %s", r.getInfo())
@@ -94,7 +116,13 @@ func (r *ReliableSuperStreamConsumer) setStatus(value int) {
 	r.mutexStatus.Lock()
 	defer r.mutexStatus.Unlock()
 	r.status = value
+	if value == StatusClosed && r.stopRetry != nil && !r.retryStopped {
+		r.retryStopped = true
+		close(r.stopRetry)
+	}
 }
+
+func (r *ReliableSuperStreamConsumer) retryStop() <-chan struct{} { return r.stopRetry }
 
 func (r *ReliableSuperStreamConsumer) getInfo() string {
 	return fmt.Sprintf("consumer %s for super stream %s",
@@ -107,6 +135,9 @@ func (r *ReliableSuperStreamConsumer) getEnv() *stream.Environment {
 
 func (r *ReliableSuperStreamConsumer) getNewInstance(partition string) newEntityInstance {
 	return func() error {
+		if r.GetStatus() == StatusClosed {
+			return stream.AlreadyClosed
+		}
 		c := r.consumer.Load()
 		// by default the consumer will start from the consumerOptions.Offset
 		off := r.consumerOptions.Offset

--- a/pkg/ha/ha_super_stream_publisher.go
+++ b/pkg/ha/ha_super_stream_publisher.go
@@ -1,6 +1,7 @@
 package ha
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -52,9 +53,8 @@ func NewReliableSuperStreamProducer(env *stream.Environment, superStream string,
 	}
 
 	ch := producer.NotifyPartitionClose(1)
+	res.handlePublishConfirm(producer.NotifyPublishConfirmation(1))
 	res.handleNotifyClose(ch)
-	chNotifyPublishConfirm := producer.NotifyPublishConfirmation(1)
-	res.handlePublishConfirm(chNotifyPublishConfirm)
 	res.producer.Store(producer)
 	res.partitionConfirmMessageHandler = partitionConfirmMessageHandler
 	res.setStatus(StatusOpen)
@@ -85,14 +85,17 @@ func (r *ReliableSuperStreamProducer) handleNotifyClose(channelClose chan stream
 				} else {
 					r.setStatus(StatusClosed)
 				}
+				r.reconnectionSignal.L.Lock()
+				r.reconnectionSignal.Broadcast()
+				r.reconnectionSignal.L.Unlock()
 			} else {
 				logs.LogInfo("[Reliable] - %s closed normally. Reason: %s", r.getInfo(), cPartitionClose.Event.Reason)
 				r.setStatus(StatusClosed)
+				r.reconnectionSignal.L.Lock()
+				r.reconnectionSignal.Broadcast()
+				r.reconnectionSignal.L.Unlock()
 				break
 			}
-			r.reconnectionSignal.L.Lock()
-			r.reconnectionSignal.Broadcast()
-			r.reconnectionSignal.L.Unlock()
 		}
 		logs.LogDebug("[ReliableSuperStreamProducer] - closed %s", r.getInfo())
 	}()
@@ -139,14 +142,29 @@ func (r *ReliableSuperStreamProducer) GetStatusAsString() string {
 }
 
 func (r *ReliableSuperStreamProducer) Send(message message.StreamMessage) error {
-	if err := isReadyToSend(r, r.reconnectionSignal); err != nil {
-		return err
-	}
-	r.mutex.Lock()
-	errW := r.producer.Load().Send(message)
-	r.mutex.Unlock()
+	for {
+		if err := isReadyToSend(r, r.reconnectionSignal); err != nil {
+			return err
+		}
+		r.mutex.Lock()
+		errW := r.producer.Load().Send(message)
+		r.mutex.Unlock()
 
-	return checkWriteError(r, errW)
+		if errors.Is(errW, stream.ErrProducerNotFound) {
+			// The partition producer was already removed from the SuperStreamProducer
+			// because its connection just dropped, but this ReliableSuperStreamProducer
+			// hasn't processed the close notification yet (status is still StatusOpen).
+			// Unlike the single-stream Producer, a super stream partition producer that
+			// no longer exists can't record the message as unconfirmed/failed, so it must
+			// not be silently dropped here. Wait for the reconnection to be handled and retry.
+			r.reconnectionSignal.L.Lock()
+			r.reconnectionSignal.Wait()
+			r.reconnectionSignal.L.Unlock()
+			continue
+		}
+
+		return checkWriteError(r, errW)
+	}
 }
 
 func (r *ReliableSuperStreamProducer) Close() error {

--- a/pkg/ha/reliable_common.go
+++ b/pkg/ha/reliable_common.go
@@ -47,6 +47,7 @@ type IReliable interface {
 func retry(backoff int, reliable IReliable, streamName string) (error, bool) {
 	waitTime := randomWaitWithBackoff(backoff)
 	logs.LogInfo("[Reliable] - The %s for the stream %s is in reconnection in %d milliseconds", reliable.getInfo(), streamName, waitTime)
+
 	// Super stream consumers expose a terminal signal so Close can interrupt
 	// backoff and drain pending partition notifications without reopening them.
 	var stopped <-chan struct{}

--- a/pkg/ha/reliable_common.go
+++ b/pkg/ha/reliable_common.go
@@ -47,8 +47,25 @@ type IReliable interface {
 func retry(backoff int, reliable IReliable, streamName string) (error, bool) {
 	waitTime := randomWaitWithBackoff(backoff)
 	logs.LogInfo("[Reliable] - The %s for the stream %s is in reconnection in %d milliseconds", reliable.getInfo(), streamName, waitTime)
-	time.Sleep(time.Duration(waitTime) * time.Millisecond)
+	// Super stream consumers expose a terminal signal so Close can interrupt
+	// backoff and drain pending partition notifications without reopening them.
+	var stopped <-chan struct{}
+	if closer, ok := reliable.(interface{ retryStop() <-chan struct{} }); ok {
+		stopped = closer.retryStop()
+	}
+	timer := time.NewTimer(time.Duration(waitTime) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-stopped:
+		return stream.AlreadyClosed, false
+	}
 	streamMetaData, errS := reliable.getEnv().StreamMetaData(streamName)
+	select {
+	case <-stopped:
+		return stream.AlreadyClosed, false
+	default:
+	}
 	if errors.Is(errS, stream.StreamDoesNotExist) {
 		logs.LogInfo("[Reliable] - The stream %s does not exist for %s. Stopping it", streamName, reliable.getInfo())
 		return errS, false
@@ -71,6 +88,9 @@ func retry(backoff int, reliable IReliable, streamName string) (error, bool) {
 	if streamMetaData != nil {
 		logs.LogInfo("[Reliable] - The stream %s exists. Reconnecting the %s.", streamName, reliable.getInfo())
 		result = reliable.getNewInstance(streamName)()
+		if errors.Is(result, stream.AlreadyClosed) {
+			return result, false
+		}
 		if result == nil {
 			logs.LogInfo("[Reliable] - The stream %s exists. %s reconnected.", reliable.getInfo(), streamName)
 		} else {

--- a/pkg/stream/close_notification_external_test.go
+++ b/pkg/stream/close_notification_external_test.go
@@ -2,64 +2,64 @@ package stream_test
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestCloseNotificationsAfterBrokerOperations(t *testing.T) {
-	env, err := stream.NewEnvironment(stream.NewEnvironmentOptions())
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, env.Close()) })
-	name := fmt.Sprintf("close-notification-%d", time.Now().UnixNano())
-	require.NoError(t, env.DeclareStream(name, stream.NewStreamOptions()))
-	t.Cleanup(func() { assert.NoError(t, env.DeleteStream(name)) })
-	producer, err := env.NewProducer(name, stream.NewProducerOptions())
-	require.NoError(t, err)
-	require.NoError(t, producer.Close())
-	select {
-	case event, ok := <-producer.NotifyClose():
-		require.True(t, ok)
-		assert.Equal(t, stream.DeletePublisher, event.Reason)
-	case <-time.After(5 * time.Second):
-		t.Fatal("producer close before registration was lost")
-	}
-	consumer, err := env.NewConsumer(name, func(stream.ConsumerContext, *amqp.Message) {}, stream.NewConsumerOptions())
-	require.NoError(t, err)
-	require.NoError(t, consumer.Close())
-	select {
-	case event, ok := <-consumer.NotifyClose():
-		require.True(t, ok)
-		assert.Equal(t, stream.UnSubscribe, event.Reason)
-	case <-time.After(5 * time.Second):
-		t.Fatal("consumer close before registration was lost")
-	}
-	superName := name + "-super"
-	require.NoError(t, env.DeclareSuperStream(superName, stream.NewPartitionsOptions(2)))
-	t.Cleanup(func() { assert.NoError(t, env.DeleteSuperStream(superName)) })
-	super, err := env.NewSuperStreamConsumer(superName, func(stream.ConsumerContext, *amqp.Message) {}, stream.NewSuperStreamConsumerOptions())
-	require.NoError(t, err)
-	require.NoError(t, super.Close())
-	events := super.NotifyPartitionClose(1)
-	var partitions []string
-	for range 2 {
-		select {
-		case event, ok := <-events:
-			require.True(t, ok, "partition events were discarded")
+var _ = Describe("Close notifications after broker operations", func() {
+	It("retains close events registered after the entity is closed", func() {
+		env, err := stream.NewEnvironment(stream.NewEnvironmentOptions())
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { Expect(env.Close()).To(Succeed()) })
+
+		name := fmt.Sprintf("close-notification-%d", time.Now().UnixNano())
+		Expect(env.DeclareStream(name, stream.NewStreamOptions())).To(Succeed())
+		DeferCleanup(func() { Expect(env.DeleteStream(name)).To(Succeed()) })
+
+		By("closing a producer before registering for its notifications")
+		producer, err := env.NewProducer(name, stream.NewProducerOptions())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(producer.Close()).To(Succeed())
+
+		var producerEvent stream.Event
+		Eventually(producer.NotifyClose(), 5*time.Second).Should(Receive(&producerEvent),
+			"producer close before registration was lost")
+		Expect(producerEvent.Reason).To(Equal(stream.DeletePublisher))
+
+		By("closing a consumer before registering for its notifications")
+		consumer, err := env.NewConsumer(name, func(stream.ConsumerContext, *amqp.Message) {}, stream.NewConsumerOptions())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(consumer.Close()).To(Succeed())
+
+		var consumerEvent stream.Event
+		Eventually(consumer.NotifyClose(), 5*time.Second).Should(Receive(&consumerEvent),
+			"consumer close before registration was lost")
+		Expect(consumerEvent.Reason).To(Equal(stream.UnSubscribe))
+
+		By("closing a super stream consumer before registering for its partition notifications")
+		superName := name + "-super"
+		Expect(env.DeclareSuperStream(superName, stream.NewPartitionsOptions(2))).To(Succeed())
+		DeferCleanup(func() { Expect(env.DeleteSuperStream(superName)).To(Succeed()) })
+
+		super, err := env.NewSuperStreamConsumer(superName, func(stream.ConsumerContext, *amqp.Message) {}, stream.NewSuperStreamConsumerOptions())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(super.Close()).To(Succeed())
+
+		events := super.NotifyPartitionClose(1)
+		partitions := make([]string, 0, 2)
+		for range 2 {
+			var event stream.CPartitionClose
+			Eventually(events, 5*time.Second).Should(Receive(&event),
+				"partition close before registration was lost")
 			partitions = append(partitions, event.Partition)
-		case <-time.After(5 * time.Second):
-			t.Fatal("partition close before registration was lost")
 		}
-	}
-	assert.ElementsMatch(t, []string{superName + "-0", superName + "-1"}, partitions)
-	select {
-	case _, ok := <-events:
-		assert.False(t, ok)
-	case <-time.After(5 * time.Second):
-		t.Fatal("partition notification channel did not close")
-	}
-}
+		Expect(partitions).To(ConsistOf(superName+"-0", superName+"-1"))
+
+		Eventually(events, 5*time.Second).Should(BeClosed(),
+			"partition notification channel did not close")
+	})
+})

--- a/pkg/stream/close_notification_external_test.go
+++ b/pkg/stream/close_notification_external_test.go
@@ -1,0 +1,65 @@
+package stream_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseNotificationsAfterBrokerOperations(t *testing.T) {
+	env, err := stream.NewEnvironment(stream.NewEnvironmentOptions())
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, env.Close()) })
+	name := fmt.Sprintf("close-notification-%d", time.Now().UnixNano())
+	require.NoError(t, env.DeclareStream(name, stream.NewStreamOptions()))
+	t.Cleanup(func() { assert.NoError(t, env.DeleteStream(name)) })
+	producer, err := env.NewProducer(name, stream.NewProducerOptions())
+	require.NoError(t, err)
+	require.NoError(t, producer.Close())
+	select {
+	case event, ok := <-producer.NotifyClose():
+		require.True(t, ok)
+		assert.Equal(t, stream.DeletePublisher, event.Reason)
+	case <-time.After(5 * time.Second):
+		t.Fatal("producer close before registration was lost")
+	}
+	consumer, err := env.NewConsumer(name, func(stream.ConsumerContext, *amqp.Message) {}, stream.NewConsumerOptions())
+	require.NoError(t, err)
+	require.NoError(t, consumer.Close())
+	select {
+	case event, ok := <-consumer.NotifyClose():
+		require.True(t, ok)
+		assert.Equal(t, stream.UnSubscribe, event.Reason)
+	case <-time.After(5 * time.Second):
+		t.Fatal("consumer close before registration was lost")
+	}
+	superName := name + "-super"
+	require.NoError(t, env.DeclareSuperStream(superName, stream.NewPartitionsOptions(2)))
+	t.Cleanup(func() { assert.NoError(t, env.DeleteSuperStream(superName)) })
+	super, err := env.NewSuperStreamConsumer(superName, func(stream.ConsumerContext, *amqp.Message) {}, stream.NewSuperStreamConsumerOptions())
+	require.NoError(t, err)
+	require.NoError(t, super.Close())
+	events := super.NotifyPartitionClose(1)
+	var partitions []string
+	for range 2 {
+		select {
+		case event, ok := <-events:
+			require.True(t, ok, "partition events were discarded")
+			partitions = append(partitions, event.Partition)
+		case <-time.After(5 * time.Second):
+			t.Fatal("partition close before registration was lost")
+		}
+	}
+	assert.ElementsMatch(t, []string{superName + "-0", superName + "-1"}, partitions)
+	select {
+	case _, ok := <-events:
+		assert.False(t, ok)
+	case <-time.After(5 * time.Second):
+		t.Fatal("partition notification channel did not close")
+	}
+}

--- a/pkg/stream/close_notification_test.go
+++ b/pkg/stream/close_notification_test.go
@@ -1,0 +1,172 @@
+package stream
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests use the coordinator to reproduce close-before-registration without
+// needing a broker or relying on a network failure arriving at a particular time.
+func TestProducerCloseBeforeNotificationRegistration(t *testing.T) {
+	producer, err := NewCoordinator().NewProducer(nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, producer.close(Event{Reason: SocketClosed}))
+	events := producer.NotifyClose()
+	assert.Equal(t, events, producer.NotifyClose())
+	select {
+	case event, ok := <-events:
+		require.True(t, ok)
+		assert.Equal(t, SocketClosed, event.Reason)
+	case <-time.After(time.Second):
+		t.Fatal("early producer close event was lost")
+	}
+	_, ok := <-events
+	assert.False(t, ok)
+}
+
+func TestConsumerCloseBeforeNotificationRegistration(t *testing.T) {
+	consumer, err := NewCoordinator().NewConsumer(nil, NewConsumerOptions(), nil)
+	require.NoError(t, err)
+	consumer.close(Event{Reason: SocketClosed})
+	events := consumer.NotifyClose()
+	assert.Equal(t, events, consumer.NotifyClose())
+	select {
+	case event, ok := <-events:
+		require.True(t, ok)
+		assert.Equal(t, SocketClosed, event.Reason)
+	case <-time.After(time.Second):
+		t.Fatal("early consumer close event was lost")
+	}
+	_, ok := <-events
+	assert.False(t, ok)
+}
+
+func TestProducerConcurrentCloseHasOneOwner(t *testing.T) {
+	for range 100 {
+		producer, err := NewCoordinator().NewProducer(nil, nil)
+		require.NoError(t, err)
+		const closers = 32
+		start := make(chan struct{})
+		results := make(chan error, closers)
+		for range closers {
+			go func() { <-start; results <- producer.close(Event{Reason: SocketClosed}) }()
+		}
+		close(start)
+		owners := 0
+		for range closers {
+			select {
+			case err := <-results:
+				if err == nil {
+					owners++
+				} else {
+					require.ErrorIs(t, err, AlreadyClosed)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("concurrent producer close blocked")
+			}
+		}
+		assert.Equal(t, 1, owners)
+		_, ok := <-producer.NotifyClose()
+		assert.True(t, ok)
+		_, ok = <-producer.NotifyClose()
+		assert.False(t, ok)
+	}
+}
+
+func TestSuperStreamRetainsPartitionEventsBeforeRegistration(t *testing.T) {
+	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+	for _, partition := range []string{"events-0", "events-1"} {
+		consumer.notifyPartitionClose(CPartitionClose{Partition: partition, Event: Event{Reason: SocketClosed}})
+	}
+	require.NoError(t, consumer.Close())
+	require.Eventually(t, func() bool {
+		consumer.chSuperStreamPartitionMutex.Lock()
+		defer consumer.chSuperStreamPartitionMutex.Unlock()
+		return consumer.partitionNotificationsClosed
+	}, time.Second, time.Millisecond)
+	events := consumer.NotifyPartitionClose(1)
+	assert.Equal(t, events, consumer.NotifyPartitionClose(10))
+	partitions := make([]string, 0, 2)
+	for event := range events {
+		partitions = append(partitions, event.Partition)
+	}
+	assert.Equal(t, []string{"events-0", "events-1"}, partitions)
+	require.NoError(t, consumer.Close())
+	require.ErrorIs(t, consumer.ConnectPartition("events-0", OffsetSpecification{}.First()), AlreadyClosed)
+}
+
+func TestSuperStreamCloseWaitsForPartitionForwarders(t *testing.T) {
+	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+	events := consumer.NotifyPartitionClose(1)
+	consumer.partitionCloseWorkers.Add(1)
+	started := make(chan struct{})
+	go func() {
+		defer consumer.partitionCloseWorkers.Done()
+		close(started)
+		consumer.notifyPartitionClose(CPartitionClose{Partition: "events-0"})
+	}()
+	<-started
+	require.NoError(t, consumer.Close())
+	// A slow reader must not lose its event to a timer-based channel close.
+	select {
+	case event, ok := <-events:
+		require.True(t, ok)
+		assert.Equal(t, "events-0", event.Partition)
+	case <-time.After(time.Second):
+		t.Fatal("partition forwarder did not complete")
+	}
+	select {
+	case _, ok := <-events:
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("partition notification channel was not closed")
+	}
+}
+
+func TestSuperStreamConcurrentNotificationRegistration(t *testing.T) {
+	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+	consumer.partitionCloseWorkers.Add(1)
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() { consumer.NotifyPartitionClose(64) })
+	}
+	wg.Go(func() {
+		defer consumer.partitionCloseWorkers.Done()
+		consumer.notifyPartitionClose(CPartitionClose{Partition: "events-0"})
+	})
+	wg.Wait()
+	assert.GreaterOrEqual(t, cap(consumer.NotifyPartitionClose(1)), 64)
+	require.NoError(t, consumer.Close())
+	events := make([]CPartitionClose, 0, 1)
+	for event := range consumer.NotifyPartitionClose(1) {
+		events = append(events, event)
+	}
+	require.Len(t, events, 1)
+	assert.Equal(t, "events-0", events[0].Partition)
+}
+
+func TestSuperStreamCloseDoesNotWaitForAbandonedReader(t *testing.T) {
+	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+	events := consumer.NotifyPartitionClose(1)
+	consumer.notifyPartitionClose(CPartitionClose{Partition: "old-event"})
+	consumer.partitionCloseWorkers.Add(1)
+	go func() {
+		defer consumer.partitionCloseWorkers.Done()
+		consumer.notifyPartitionClose(CPartitionClose{Partition: "shutdown-event"})
+	}()
+	require.NoError(t, consumer.Close())
+	require.Eventually(t, func() bool {
+		consumer.chSuperStreamPartitionMutex.Lock()
+		defer consumer.chSuperStreamPartitionMutex.Unlock()
+		return consumer.partitionNotificationsClosed
+	}, time.Second, time.Millisecond)
+	event, ok := <-events
+	require.True(t, ok)
+	assert.Equal(t, "old-event", event.Partition)
+	_, ok = <-events
+	assert.False(t, ok)
+}

--- a/pkg/stream/close_notification_test.go
+++ b/pkg/stream/close_notification_test.go
@@ -2,171 +2,184 @@ package stream
 
 import (
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// These tests use the coordinator to reproduce close-before-registration without
+// These specs use the coordinator to reproduce close-before-registration without
 // needing a broker or relying on a network failure arriving at a particular time.
-func TestProducerCloseBeforeNotificationRegistration(t *testing.T) {
-	producer, err := NewCoordinator().NewProducer(nil, nil)
-	require.NoError(t, err)
-	require.NoError(t, producer.close(Event{Reason: SocketClosed}))
-	events := producer.NotifyClose()
-	assert.Equal(t, events, producer.NotifyClose())
-	select {
-	case event, ok := <-events:
-		require.True(t, ok)
-		assert.Equal(t, SocketClosed, event.Reason)
-	case <-time.After(time.Second):
-		t.Fatal("early producer close event was lost")
-	}
-	_, ok := <-events
-	assert.False(t, ok)
-}
-
-func TestConsumerCloseBeforeNotificationRegistration(t *testing.T) {
-	consumer, err := NewCoordinator().NewConsumer(nil, NewConsumerOptions(), nil)
-	require.NoError(t, err)
-	consumer.close(Event{Reason: SocketClosed})
-	events := consumer.NotifyClose()
-	assert.Equal(t, events, consumer.NotifyClose())
-	select {
-	case event, ok := <-events:
-		require.True(t, ok)
-		assert.Equal(t, SocketClosed, event.Reason)
-	case <-time.After(time.Second):
-		t.Fatal("early consumer close event was lost")
-	}
-	_, ok := <-events
-	assert.False(t, ok)
-}
-
-func TestProducerConcurrentCloseHasOneOwner(t *testing.T) {
-	for range 100 {
+var _ = Describe("Close notification retention", func() {
+	It("retains a producer close event registered after the close", func() {
 		producer, err := NewCoordinator().NewProducer(nil, nil)
-		require.NoError(t, err)
-		const closers = 32
-		start := make(chan struct{})
-		results := make(chan error, closers)
-		for range closers {
-			go func() { <-start; results <- producer.close(Event{Reason: SocketClosed}) }()
-		}
-		close(start)
-		owners := 0
-		for range closers {
-			select {
-			case err := <-results:
-				if err == nil {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(producer.close(Event{Reason: SocketClosed})).To(Succeed())
+
+		events := producer.NotifyClose()
+		Expect(producer.NotifyClose()).To(BeIdenticalTo(events), "each call must return the same channel")
+
+		var event Event
+		Eventually(events, time.Second).Should(Receive(&event), "early producer close event was lost")
+		Expect(event.Reason).To(Equal(SocketClosed))
+		Eventually(events, time.Second).Should(BeClosed())
+	})
+
+	It("retains a consumer close event registered after the close", func() {
+		consumer, err := NewCoordinator().NewConsumer(nil, NewConsumerOptions(), nil)
+		Expect(err).NotTo(HaveOccurred())
+		consumer.close(Event{Reason: SocketClosed})
+
+		events := consumer.NotifyClose()
+		Expect(consumer.NotifyClose()).To(BeIdenticalTo(events), "each call must return the same channel")
+
+		var event Event
+		Eventually(events, time.Second).Should(Receive(&event), "early consumer close event was lost")
+		Expect(event.Reason).To(Equal(SocketClosed))
+		Eventually(events, time.Second).Should(BeClosed())
+	})
+
+	It("gives concurrent producer closes exactly one owner", func() {
+		for range 100 {
+			producer, err := NewCoordinator().NewProducer(nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			const closers = 32
+			start := make(chan struct{})
+			results := make(chan error, closers)
+			for range closers {
+				go func() {
+					defer GinkgoRecover()
+					<-start
+					results <- producer.close(Event{Reason: SocketClosed})
+				}()
+			}
+			close(start)
+
+			owners := 0
+			for range closers {
+				var closeErr error
+				Eventually(results, time.Second).Should(Receive(&closeErr), "concurrent producer close blocked")
+				if closeErr == nil {
 					owners++
 				} else {
-					require.ErrorIs(t, err, AlreadyClosed)
+					Expect(closeErr).To(MatchError(AlreadyClosed))
 				}
-			case <-time.After(time.Second):
-				t.Fatal("concurrent producer close blocked")
 			}
+			Expect(owners).To(Equal(1))
+
+			events := producer.NotifyClose()
+			Eventually(events, time.Second).Should(Receive())
+			Eventually(events, time.Second).Should(BeClosed())
 		}
-		assert.Equal(t, 1, owners)
-		_, ok := <-producer.NotifyClose()
-		assert.True(t, ok)
-		_, ok = <-producer.NotifyClose()
-		assert.False(t, ok)
-	}
-}
-
-func TestSuperStreamRetainsPartitionEventsBeforeRegistration(t *testing.T) {
-	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
-	for _, partition := range []string{"events-0", "events-1"} {
-		consumer.notifyPartitionClose(CPartitionClose{Partition: partition, Event: Event{Reason: SocketClosed}})
-	}
-	require.NoError(t, consumer.Close())
-	require.Eventually(t, func() bool {
-		consumer.chSuperStreamPartitionMutex.Lock()
-		defer consumer.chSuperStreamPartitionMutex.Unlock()
-		return consumer.partitionNotificationsClosed
-	}, time.Second, time.Millisecond)
-	events := consumer.NotifyPartitionClose(1)
-	assert.Equal(t, events, consumer.NotifyPartitionClose(10))
-	partitions := make([]string, 0, 2)
-	for event := range events {
-		partitions = append(partitions, event.Partition)
-	}
-	assert.Equal(t, []string{"events-0", "events-1"}, partitions)
-	require.NoError(t, consumer.Close())
-	require.ErrorIs(t, consumer.ConnectPartition("events-0", OffsetSpecification{}.First()), AlreadyClosed)
-}
-
-func TestSuperStreamCloseWaitsForPartitionForwarders(t *testing.T) {
-	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
-	events := consumer.NotifyPartitionClose(1)
-	consumer.partitionCloseWorkers.Add(1)
-	started := make(chan struct{})
-	go func() {
-		defer consumer.partitionCloseWorkers.Done()
-		close(started)
-		consumer.notifyPartitionClose(CPartitionClose{Partition: "events-0"})
-	}()
-	<-started
-	require.NoError(t, consumer.Close())
-	// A slow reader must not lose its event to a timer-based channel close.
-	select {
-	case event, ok := <-events:
-		require.True(t, ok)
-		assert.Equal(t, "events-0", event.Partition)
-	case <-time.After(time.Second):
-		t.Fatal("partition forwarder did not complete")
-	}
-	select {
-	case _, ok := <-events:
-		assert.False(t, ok)
-	case <-time.After(time.Second):
-		t.Fatal("partition notification channel was not closed")
-	}
-}
-
-func TestSuperStreamConcurrentNotificationRegistration(t *testing.T) {
-	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
-	consumer.partitionCloseWorkers.Add(1)
-	var wg sync.WaitGroup
-	for range 20 {
-		wg.Go(func() { consumer.NotifyPartitionClose(64) })
-	}
-	wg.Go(func() {
-		defer consumer.partitionCloseWorkers.Done()
-		consumer.notifyPartitionClose(CPartitionClose{Partition: "events-0"})
 	})
-	wg.Wait()
-	assert.GreaterOrEqual(t, cap(consumer.NotifyPartitionClose(1)), 64)
-	require.NoError(t, consumer.Close())
-	events := make([]CPartitionClose, 0, 1)
-	for event := range consumer.NotifyPartitionClose(1) {
-		events = append(events, event)
-	}
-	require.Len(t, events, 1)
-	assert.Equal(t, "events-0", events[0].Partition)
-}
+})
 
-func TestSuperStreamCloseDoesNotWaitForAbandonedReader(t *testing.T) {
-	consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
-	events := consumer.NotifyPartitionClose(1)
-	consumer.notifyPartitionClose(CPartitionClose{Partition: "old-event"})
-	consumer.partitionCloseWorkers.Add(1)
-	go func() {
-		defer consumer.partitionCloseWorkers.Done()
-		consumer.notifyPartitionClose(CPartitionClose{Partition: "shutdown-event"})
-	}()
-	require.NoError(t, consumer.Close())
-	require.Eventually(t, func() bool {
-		consumer.chSuperStreamPartitionMutex.Lock()
-		defer consumer.chSuperStreamPartitionMutex.Unlock()
-		return consumer.partitionNotificationsClosed
-	}, time.Second, time.Millisecond)
-	event, ok := <-events
-	require.True(t, ok)
-	assert.Equal(t, "old-event", event.Partition)
-	_, ok = <-events
-	assert.False(t, ok)
-}
+var _ = Describe("Super stream partition notifications", func() {
+	// partitionsClosed reports the mutex-guarded shutdown flag for polling.
+	partitionsClosed := func(consumer *SuperStreamConsumer) func() bool {
+		return func() bool {
+			consumer.chSuperStreamPartitionMutex.Lock()
+			defer consumer.chSuperStreamPartitionMutex.Unlock()
+			return consumer.partitionNotificationsClosed
+		}
+	}
+
+	It("retains partition events registered after the close", func() {
+		consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+		for _, partition := range []string{"events-0", "events-1"} {
+			consumer.notifyPartitionClose(CPartitionClose{Partition: partition, Event: Event{Reason: SocketClosed}})
+		}
+		Expect(consumer.Close()).To(Succeed())
+		Eventually(partitionsClosed(consumer)).WithTimeout(time.Second).WithPolling(time.Millisecond).
+			Should(BeTrue())
+
+		events := consumer.NotifyPartitionClose(1)
+		Expect(consumer.NotifyPartitionClose(10)).To(BeIdenticalTo(events),
+			"each call must return the same channel")
+
+		partitions := make([]string, 0, 2)
+		for event := range events {
+			partitions = append(partitions, event.Partition)
+		}
+		Expect(partitions).To(Equal([]string{"events-0", "events-1"}))
+
+		Expect(consumer.Close()).To(Succeed(), "Close must be idempotent")
+		Expect(consumer.ConnectPartition("events-0", OffsetSpecification{}.First())).
+			To(MatchError(AlreadyClosed))
+	})
+
+	It("waits for in-flight partition forwarders on Close", func() {
+		consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+		events := consumer.NotifyPartitionClose(1)
+
+		consumer.partitionCloseWorkers.Add(1)
+		started := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer consumer.partitionCloseWorkers.Done()
+			close(started)
+			consumer.notifyPartitionClose(CPartitionClose{Partition: "events-0"})
+		}()
+
+		Eventually(started, time.Second).Should(BeClosed())
+		Expect(consumer.Close()).To(Succeed())
+
+		// A slow reader must not lose its event to a timer-based channel close.
+		var event CPartitionClose
+		Eventually(events, time.Second).Should(Receive(&event), "partition forwarder did not complete")
+		Expect(event.Partition).To(Equal("events-0"))
+		Eventually(events, time.Second).Should(BeClosed(), "partition notification channel was not closed")
+	})
+
+	It("honours the largest requested buffer under concurrent registration", func() {
+		consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+		consumer.partitionCloseWorkers.Add(1)
+
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Go(func() {
+				defer GinkgoRecover()
+				consumer.NotifyPartitionClose(64)
+			})
+		}
+		wg.Go(func() {
+			defer GinkgoRecover()
+			defer consumer.partitionCloseWorkers.Done()
+			consumer.notifyPartitionClose(CPartitionClose{Partition: "events-0"})
+		})
+		wg.Wait()
+
+		Expect(cap(consumer.NotifyPartitionClose(1))).To(BeNumerically(">=", 64))
+		Expect(consumer.Close()).To(Succeed())
+
+		events := make([]CPartitionClose, 0, 1)
+		for event := range consumer.NotifyPartitionClose(1) {
+			events = append(events, event)
+		}
+		Expect(events).To(HaveLen(1))
+		Expect(events[0].Partition).To(Equal("events-0"))
+	})
+
+	It("does not wait for an abandoned reader", func() {
+		consumer := &SuperStreamConsumer{stopPartitionForwarding: make(chan struct{})}
+		events := consumer.NotifyPartitionClose(1)
+		consumer.notifyPartitionClose(CPartitionClose{Partition: "old-event"})
+
+		consumer.partitionCloseWorkers.Add(1)
+		go func() {
+			defer GinkgoRecover()
+			defer consumer.partitionCloseWorkers.Done()
+			consumer.notifyPartitionClose(CPartitionClose{Partition: "shutdown-event"})
+		}()
+
+		Expect(consumer.Close()).To(Succeed())
+		Eventually(partitionsClosed(consumer)).WithTimeout(time.Second).WithPolling(time.Millisecond).
+			Should(BeTrue())
+
+		var event CPartitionClose
+		Eventually(events, time.Second).Should(Receive(&event))
+		Expect(event.Partition).To(Equal("old-event"))
+		Eventually(events, time.Second).Should(BeClosed())
+	})
+})

--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -157,12 +157,10 @@ func (consumer *Consumer) GetCloseHandler() chan Event {
 	return consumer.closeHandler
 }
 
+// NotifyClose returns the consumer close notification channel, including an event
+// emitted before registration. Repeated calls return the same channel.
 func (consumer *Consumer) NotifyClose() ChannelClose {
-	consumer.mutex.Lock()
-	defer consumer.mutex.Unlock()
-	ch := make(chan Event, 1)
-	consumer.closeHandler = ch
-	return ch
+	return consumer.closeHandler
 }
 
 func (consumer *Consumer) Credit(credits int16) error {
@@ -447,7 +445,6 @@ func (consumer *Consumer) close(reason Event) {
 		if closeHandler := consumer.GetCloseHandler(); closeHandler != nil {
 			closeHandler <- reason
 			close(consumer.closeHandler)
-			consumer.closeHandler = nil
 		}
 
 		if consumer.response.data != nil {

--- a/pkg/stream/coordinator.go
+++ b/pkg/stream/coordinator.go
@@ -67,6 +67,7 @@ func (coordinator *Coordinator) NewProducer(
 		return nil, err
 	}
 	var producer = &Producer{
+		closeHandler:              make(chan Event, 1),
 		options:                   parameters,
 		mutex:                     &sync.RWMutex{},
 		unConfirmed:               newUnConfirmed(queueSize),
@@ -192,6 +193,7 @@ func (coordinator *Coordinator) NewConsumer(
 		return nil, err
 	}
 	var consumer = &Consumer{
+		closeHandler:         make(chan Event, 1),
 		options:              parameters,
 		response:             newResponse(lookUpCommand(commandSubscribe)),
 		status:               open,

--- a/pkg/stream/producer.go
+++ b/pkg/stream/producer.go
@@ -72,13 +72,14 @@ type messageSequence struct {
 }
 
 type Producer struct {
-	client      *Client
-	id          uint8
-	options     *ProducerOptions
-	onClose     func()
-	unConfirmed *unConfirmed
-	sequence    int64
-	mutex       *sync.RWMutex
+	closeStarted atomic.Bool
+	client       *Client
+	id           uint8
+	options      *ProducerOptions
+	onClose      func()
+	unConfirmed  *unConfirmed
+	sequence     int64
+	mutex        *sync.RWMutex
 
 	closeHandler              chan Event
 	status                    int
@@ -235,13 +236,10 @@ func (producer *Producer) NotifyPublishConfirmation() ChannelPublishConfirm {
 	return ch
 }
 
-// NotifyClose returns a channel that receives the close event of the producer.
+// NotifyClose returns the producer close notification channel, including an event
+// emitted before registration. Repeated calls return the same channel.
 func (producer *Producer) NotifyClose() ChannelClose {
-	ch := make(chan Event, 1)
-	producer.mutex.Lock()
-	producer.closeHandler = ch
-	producer.mutex.Unlock()
-	return ch
+	return producer.closeHandler
 }
 
 func (producer *Producer) GetOptions() *ProducerOptions {
@@ -786,7 +784,7 @@ func (producer *Producer) Close() error {
 	})
 }
 func (producer *Producer) close(reason Event) error {
-	if producer.getStatus() == closed {
+	if !producer.closeStarted.CompareAndSwap(false, true) {
 		return AlreadyClosed
 	}
 
@@ -797,7 +795,6 @@ func (producer *Producer) close(reason Event) error {
 
 	producer.mutex.Lock()
 	ch := producer.closeHandler
-	producer.closeHandler = nil
 	producer.mutex.Unlock()
 	if ch != nil {
 		ch <- reason

--- a/pkg/stream/super_stream_consumer.go
+++ b/pkg/stream/super_stream_consumer.go
@@ -1,9 +1,9 @@
 package stream
 
 import (
+	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"slices"
 
@@ -91,8 +91,13 @@ type SuperStreamConsumer struct {
 	env        *Environment
 	mutex      sync.Mutex
 
-	chSuperStreamPartitionMutex sync.Mutex
-	chSuperStreamPartitionClose chan CPartitionClose
+	chSuperStreamPartitionMutex  sync.Mutex
+	chSuperStreamPartitionClose  chan CPartitionClose
+	pendingPartitionClose        []CPartitionClose
+	partitionNotificationsClosed bool
+	partitionCloseWorkers        sync.WaitGroup
+	stopPartitionForwarding      chan struct{}
+	closed                       bool
 
 	SuperStream                string
 	SuperStreamConsumerOptions *SuperStreamConsumerOptions
@@ -117,6 +122,7 @@ func newSuperStreamConsumer(env *Environment, superStream string, messagesHandle
 
 	return &SuperStreamConsumer{
 		env:                        env,
+		stopPartitionForwarding:    make(chan struct{}),
 		SuperStream:                superStream,
 		SuperStreamConsumerOptions: superStreamConsumerOptions,
 		MessagesHandler:            messagesHandler,
@@ -138,13 +144,47 @@ func (s *SuperStreamConsumer) init() error {
 	return nil
 }
 
-// NotifyPartitionClose returns a channel that will be notified when a partition is closed
-// Event will give the reason of the close
-// size is the size of the channel
+// NotifyPartitionClose returns the partition close notification channel. Events
+// emitted before registration are retained. The buffer holds at least size events
+// and is enlarged to hold one event per partition or retained events. Repeated
+// calls return the same channel. Close does not wait for readers: if the buffer
+// is already full during shutdown, further notifications may be discarded.
 func (s *SuperStreamConsumer) NotifyPartitionClose(size int) chan CPartitionClose {
-	ch := make(chan CPartitionClose, size)
-	s.chSuperStreamPartitionClose = ch
-	return ch
+	s.chSuperStreamPartitionMutex.Lock()
+	defer s.chSuperStreamPartitionMutex.Unlock()
+	if s.chSuperStreamPartitionClose == nil {
+		s.chSuperStreamPartitionClose = make(chan CPartitionClose, max(size, len(s.partitions), len(s.pendingPartitionClose)))
+		for _, event := range s.pendingPartitionClose {
+			s.chSuperStreamPartitionClose <- event
+		}
+		s.pendingPartitionClose = nil
+		if s.partitionNotificationsClosed {
+			close(s.chSuperStreamPartitionClose)
+		}
+	}
+	return s.chSuperStreamPartitionClose
+}
+
+func (s *SuperStreamConsumer) notifyPartitionClose(event CPartitionClose) {
+	s.chSuperStreamPartitionMutex.Lock()
+	if s.chSuperStreamPartitionClose == nil {
+		s.pendingPartitionClose = append(s.pendingPartitionClose, event)
+		s.chSuperStreamPartitionMutex.Unlock()
+		return
+	}
+	ch := s.chSuperStreamPartitionClose
+	s.chSuperStreamPartitionMutex.Unlock()
+	// Prefer retaining the event whenever buffer space exists, including after
+	// Close begins. An abandoned reader must not block shutdown indefinitely.
+	select {
+	case ch <- event:
+		return
+	default:
+	}
+	select {
+	case ch <- event:
+	case <-s.stopPartitionForwarding:
+	}
 }
 
 func (s *SuperStreamConsumer) getConsumers() []*Consumer {
@@ -156,6 +196,10 @@ func (s *SuperStreamConsumer) getConsumers() []*Consumer {
 func (s *SuperStreamConsumer) ConnectPartition(partition string, offset OffsetSpecification) error {
 	logs.LogDebug("[SuperStreamConsumer] ConnectPartition for partition: %s", partition)
 	s.mutex.Lock()
+	if s.closed {
+		s.mutex.Unlock()
+		return AlreadyClosed
+	}
 	found := slices.Contains(s.partitions, partition)
 	if !found {
 		s.mutex.Unlock()
@@ -211,11 +255,18 @@ func (s *SuperStreamConsumer) ConnectPartition(partition string, offset OffsetSp
 		return err
 	}
 	s.mutex.Lock()
+	if s.closed {
+		s.mutex.Unlock()
+		_ = consumer.Close()
+		return AlreadyClosed
+	}
 	s.activeConsumers = append(s.activeConsumers, consumer)
+	s.partitionCloseWorkers.Add(1)
 	closedEvent := consumer.NotifyClose()
 	s.mutex.Unlock()
 
 	go func(gpartion string, _closedEvent <-chan Event) {
+		defer s.partitionCloseWorkers.Done()
 		logs.LogDebug("[SuperStreamConsumer] chSuperStreamPartitionClose started for partition: %s", gpartion)
 		// one shot event
 		event := <-_closedEvent
@@ -227,15 +278,7 @@ func (s *SuperStreamConsumer) ConnectPartition(partition string, offset OffsetSp
 			}
 		}
 		s.mutex.Unlock()
-		s.chSuperStreamPartitionMutex.Lock()
-		if s.chSuperStreamPartitionClose != nil {
-			s.chSuperStreamPartitionClose <- CPartitionClose{
-				Partition: gpartion,
-				Event:     event,
-				Context:   s,
-			}
-		}
-		s.chSuperStreamPartitionMutex.Unlock()
+		s.notifyPartitionClose(CPartitionClose{Partition: gpartion, Event: event, Context: s})
 		logs.LogDebug("[SuperStreamConsumer] chSuperStreamPartitionClose for partition: %s", gpartion)
 	}(partition, closedEvent)
 
@@ -245,25 +288,34 @@ func (s *SuperStreamConsumer) ConnectPartition(partition string, offset OffsetSp
 func (s *SuperStreamConsumer) Close() error {
 	logs.LogDebug("[SuperStreamConsumer] Closing SuperStreamConsumer for: %s", s.SuperStream)
 	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	for len(s.activeConsumers) > 0 {
-		err := s.activeConsumers[0].Close()
-		if err != nil {
-			return err
-		}
-		s.activeConsumers = s.activeConsumers[1:]
+	if s.closed {
+		s.mutex.Unlock()
+		return nil
 	}
-
-	// give the time to raise the close event
+	s.closed = true
+	if s.stopPartitionForwarding != nil {
+		close(s.stopPartitionForwarding)
+	}
+	consumers := s.activeConsumers
+	s.activeConsumers = nil
+	s.mutex.Unlock()
+	var result error
+	for _, consumer := range consumers {
+		if err := consumer.Close(); err != nil && !errors.Is(err, AlreadyClosed) {
+			result = errors.Join(result, err)
+		}
+	}
+	// Each registered partition worker finishes before the notification channel
+	// is closed. No timer or caller registration is needed.
 	go func() {
-		time.Sleep(2 * time.Second)
+		s.partitionCloseWorkers.Wait()
 		s.chSuperStreamPartitionMutex.Lock()
+		defer s.chSuperStreamPartitionMutex.Unlock()
+		s.partitionNotificationsClosed = true
 		if s.chSuperStreamPartitionClose != nil {
 			close(s.chSuperStreamPartitionClose)
 		}
-		s.chSuperStreamPartitionMutex.Unlock()
 	}()
-
 	logs.LogDebug("[SuperStreamConsumer] Closed SuperStreamConsumer for: %s", s.SuperStream)
-	return nil
+	return result
 }


### PR DESCRIPTION
A broker connection can close before an application registers `NotifyClose()`. The current registration creates a new channel and discards that event, leaving ordinary and HA clients waiting for a notification that will never arrive. Concurrent producer closes can also enter teardown twice.

Retain producer and consumer close channels from construction, elect one producer teardown owner, and preserve super stream partition events until registration. Repeated registration returns the same channel. Super stream shutdown now waits for forwarding workers instead of a two-second timer. Its buffer holds at least one event per partition; an already-full abandoned buffer can drop further shutdown notifications so it cannot leak blocked forwarders. HA clients publish their initial state before processing notifications, drain terminal partition events, and stop super stream retry backoff on Close.

Validation:
- Deterministic early-registration, concurrent-close, abandoned-reader, and HA draining regressions pass under the race detector (10 repetitions; HA draining and Close-during-backoff additionally 100 repetitions).
- The producer and consumer early-registration regressions fail against unmodified `b9458d2`.
- Broker-backed close-registration regression passes 10 repetitions using the upstream TLS broker fixture in an isolated container.
- Full race-enabled stream suite: 230/230 specs; HA suite: 16/16 specs; integration suite: 2/2 specs.
- `go vet ./...` and the CI-pinned golangci-lint v2.6.2 pass.

Public method signatures are unchanged. The changelog and notification API comments describe the retained-channel and shutdown behavior.
